### PR TITLE
Make Net::LDAP use UTF-8 strings

### DIFF
--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -295,6 +295,8 @@ class Net::BER::BerIdentifiedString < String
   attr_accessor :ber_identifier
   def initialize args
     super args
+    # LDAP uses UTF-8 encoded strings
+    force_encoding('UTF-8') if respond_to?(:encoding)
   end
 end
 

--- a/lib/net/ber/core_ext/string.rb
+++ b/lib/net/ber/core_ext/string.rb
@@ -12,8 +12,20 @@ module Net::BER::Extensions::String
   # User code should call either #to_ber_application_string or
   # #to_ber_contextspecific.
   def to_ber(code = 0x04)
-    [code].pack('C') + length.to_ber_length_encoding + self
+    raw_string = raw_utf8_encoded
+    [code].pack('C') + raw_string.length.to_ber_length_encoding + raw_string
   end
+
+  def raw_utf8_encoded
+    if self.respond_to?(:encode)
+      # Strings should be UTF-8 encoded according to LDAP.
+      # However, the BER code is not necessarily valid UTF-8
+      self.encode('UTF-8').force_encoding('ASCII-8BIT')
+    else
+      self
+    end
+  end
+  private :raw_utf8_encoded
 
   ##
   # Creates an application-specific BER string encoded value with the

--- a/spec/unit/ber/ber_spec.rb
+++ b/spec/unit/ber/ber_spec.rb
@@ -75,6 +75,21 @@ describe "BER encoding of" do
       end 
     end
   end
+  if "Ruby 1.9".respond_to?(:encoding)
+    context "strings" do
+      it "should properly encode UTF-8 strings" do
+        "\u00e5".force_encoding("UTF-8").to_ber.should ==
+          "\x04\x02\xC3\xA5"
+      end
+      it "should properly encode strings encodable as UTF-8" do
+        "teststring".encode("US-ASCII").to_ber.should == "\x04\nteststring"
+      end
+      it "should fail on strings that can not be converted to UTF-8" do
+        error = Encoding::UndefinedConversionError
+        lambda {"\x81".to_ber }.should raise_exception(error)
+      end
+    end
+  end
 end
 
 describe "BER decoding of" do


### PR DESCRIPTION
RFC 2251 (section 4.1.2) states that strings should be encoded as UTF-8. Thus, strings sent with Net::LDAP should be encoded as UTF-8, and strings returned by Net::LDAP should also be UTF-8 encoded. This patch ensures this.

State before this patch:
Any string encoded as UTF-8 containing non ASCII-compatible characters would result in mixed encoding exceptions. Any data could be sent as long as it was encoded as "ASCII-8BIT". Strings returned from Net::LDAP (e.g. search results) were returned as "ASCII-8BIT".

State after this patch:
UTF-8 strings are now handled properly. Strings in other encodings are encoded as UTF-8 if possible, or otherwise an encoding error is raised (see test). Strings returned from Net::LDAP (e.g. search results) are also UTF-8 encoded.

Tests and specs pass with 1.8.7 and 1.9.2. Also tested against an OpenLDAP server.

Please test this with your own setups and report any regressions.

Alternative approaches considered:
An alternative approach to avoiding encoding errors would be to make sure that Net::LDAP always uses UTF-8 encoded strings internally. An incomplete (and failed) approach to this can be found in the "use_utf8_internally" branch of danabr/ruby-net-ldap. There are two major reasons this is a bad idea:
- Only strings must be UTF-8. Encoding things as BER encoded numbers with UTF-8 does not necessarily lead to valid UTF-8 strings. It is therefore better to use "ASCII-8BIT" as a BER string truly consists of raw bytes.
- There are lots of places where ASCII-encoded data is generated. Almost every call to pack results in "ASCII-8BIT" encoded data, as does calls to #to_s on primitives such as numbers and symbols. Another example is Array#join which, depending on the content of the array, can give results in any kind of encoding. Even if we could find and "fix" all those things in the codebase, it would put an unmaintainable burden on future contributors. BER encoding/decoding is byte oriented, and thus the parts dealing with it in Net::LDAP should be too.

/cc @Jamstah
