### PR TITLE
search should return result set if :return_result is unspecified (nil).

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -619,7 +619,8 @@ class Net::LDAP
     end
 
     args[:base] ||= @base
-    result_set = args[:return_result] == false ? nil : []
+    return_result_set = args[:return_result] != false
+    result_set = return_result_set ? [] : nil
 
     if @open_connection
       @result = @open_connection.search(args) { |entry|
@@ -642,7 +643,7 @@ class Net::LDAP
       end
     end
 
-    if args[:return_result]
+    if return_result_set
       @result == 0 ? result_set : nil
     else
       @result == 0

--- a/spec/unit/ldap/search_spec.rb
+++ b/spec/unit/ldap/search_spec.rb
@@ -13,17 +13,24 @@ describe Net::LDAP, "search method" do
     @connection.instance_variable_set(:@open_connection, FakeConnection.new)
   end
 
-  context "when returning result set" do
+  context "when :return_result => true" do
     it "should return nil upon error" do
       result_set = @connection.search(:return_result => true)
       result_set.should be_nil
     end
   end
 
-  context "when returning boolean" do
+  context "when :return_result => false" do
     it "should return false upon error" do
       success = @connection.search(:return_result => false)
       success.should == false
+    end
+  end
+
+  context "When :return_result is not given" do
+    it "should return nil upon error" do
+      result_set = @connection.search
+      result_set.should be_nil
     end
   end
 end


### PR DESCRIPTION
Corrects incorrect behaviour introduced in a4819e525f29d83357a298065df06acf5903b1af,
which broke search_root_dse and others.
