### PR TITLE
salted sha1 for password generator()

### DIFF
--- a/lib/net/ldap/password.rb
+++ b/lib/net/ldap/password.rb
@@ -1,31 +1,37 @@
 # -*- ruby encoding: utf-8 -*-
 require 'digest/sha1'
 require 'digest/md5'
+require 'base64'
 
 class Net::LDAP::Password
   class << self
     # Generate a password-hash suitable for inclusion in an LDAP attribute.
-    # Pass a hash type (currently supported: :md5 and :sha) and a plaintext
+    # Pass a hash type as a symbol (:md5, :sha, :ssha) and a plaintext
     # password. This function will return a hashed representation.
     #
     #--
     # STUB: This is here to fulfill the requirements of an RFC, which
     # one?
     #
-    # TODO, gotta do salted-sha and (maybe)salted-md5. Should we provide
-    # sha1 as a synonym for sha1? I vote no because then should you also
-    # provide ssha1 for symmetry?
+    # TODO:
+    # * maybe salted-md5
+    # * Should we provide sha1 as a synonym for sha1? I vote no because then
+    #   should you also provide ssha1 for symmetry?
+    #
+    attribute_value = ""
     def generate(type, str)
-      digest, digest_name = case type
-                            when :md5
-                              [Digest::MD5.new, 'MD5']
-                            when :sha
-                              [Digest::SHA1.new, 'SHA']
-                            else
-                              raise Net::LDAP::LdapError, "Unsupported password-hash type (#{type})"
-                            end
-      digest << str.to_s
-      return "{#{digest_name}}#{[digest.digest].pack('m').chomp }"
+       case type
+         when :md5
+            attribute_value = '{MD5}' + Base64.encode64(Digest::MD5.digest(str)).chomp! 
+         when :sha
+            attribute_value = '{SHA}' + Base64.encode64(Digest::SHA1.digest(str)).chomp! 
+         when :ssha
+            srand; salt = (rand * 1000).to_i.to_s 
+            attribute_value = '{SSHA}' + Base64.encode64(Digest::SHA1.digest(str + salt) + salt).chomp!
+         else
+            raise Net::LDAP::LdapError, "Unsupported password-hash type (#{type})"
+         end
+      return attribute_value
     end
   end
 end


### PR DESCRIPTION
Salted SHA1 {SSHA} added to the password generator. This was tested with OpenLDAP 2.4 server. Required expanding out the concise DRY implementation to allow for more complex digest.
