### PR TITLE
Parse UTF-8 special-chars in Net::LDAP::Filter.construct()

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -733,7 +733,7 @@ class Net::LDAP::Filter
         scanner.scan(/\s*/)
         if op = scanner.scan(/<=|>=|!=|:=|=/)
           scanner.scan(/\s*/)
-          if value = scanner.scan(/(?:[-\w*.+@=,#\$%&!'\s]|\\[a-fA-F\d]{2})+/)
+          if value = scanner.scan(/(?:[-\w*.+@=,#\$%&!'\s\xC3\x80-\xCA\xAF]|\\[a-fA-F\d]{2})+/)
             # 20100313 AZ: Assumes that "(uid=george*)" is the same as
             # "(uid=george* )". The standard doesn't specify, but I can find
             # no examples that suggest otherwise.


### PR DESCRIPTION
I had the Problem that LDAP-Filter strings including german special-characters like 'ü' were not correctly parsed (in ruby-1.8.7).
For instance construct("cn=mü*") resulted in a parsed filter string of "cn=m".

I added the most common european UTF-8 special-chars to the regexp.
Probably there is a better way to do that, but it seems to work for me.
