### PR TITLE
Changed back return values in API methods to match what documentation says

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -519,15 +519,17 @@ class Net::LDAP
   # response codes instead of a simple numeric code.
   #++
   def get_operation_result
+    result = @result
+    result = result.result if result.is_a?(Net::LDAP::PDU)
     os = OpenStruct.new
-    if @result.is_a?(Hash)
+    if result.is_a?(Hash)
       # We might get a hash of LDAP response codes instead of a simple
       # numeric code.
-      os.code = (@result[:resultCode] || "").to_i
-      os.error_message = @result[:errorMessage]
-      os.matched_dn = @result[:matchedDN]
-    elsif @result
-      os.code = @result
+      os.code = (result[:resultCode] || "").to_i
+      os.error_message = result[:errorMessage]
+      os.matched_dn = result[:matchedDN]
+    elsif result
+      os.code = result
     else
       os.code = 0
     end
@@ -649,7 +651,7 @@ class Net::LDAP
     if return_result_set
       (!@result.nil? && @result.result_code == 0) ? result_set : nil
     else
-      @result
+      @result.success?
     end
   end
 
@@ -723,7 +725,7 @@ class Net::LDAP
       end
     end
 
-    @result
+    @result.success?
   end
 
   # #bind_as is for testing authentication credentials.
@@ -825,7 +827,7 @@ class Net::LDAP
         conn.close if conn
       end
     end
-    @result
+    @result.success?
   end
 
   # Modifies the attribute values of a particular entry on the LDAP
@@ -924,7 +926,7 @@ class Net::LDAP
       end
     end
 
-    @result
+    @result.success?
   end
 
   # Add a value to an attribute. Takes the full DN of the entry to modify,
@@ -995,7 +997,7 @@ class Net::LDAP
         conn.close if conn
       end
     end
-    @result
+    @result.success?
   end
   alias_method :modify_rdn, :rename
 
@@ -1023,7 +1025,7 @@ class Net::LDAP
         conn.close
       end
     end
-    @result
+    @result.success?
   end
 
   # Delete an entry from the LDAP directory along with all subordinate entries.


### PR DESCRIPTION
Commit 2763040162d6ec432234c21d4c6a837c559c3ac2 broke the API, returning always a PDU, when the docs states that the return value should be a boolean depending on the status of the operation performed.
