### PR TITLE
Fall back if string cannot be encoded

### DIFF
--- a/lib/net/ber/core_ext/string.rb
+++ b/lib/net/ber/core_ext/string.rb
@@ -20,7 +20,11 @@ module Net::BER::Extensions::String
     if self.respond_to?(:encode)
       # Strings should be UTF-8 encoded according to LDAP.
       # However, the BER code is not necessarily valid UTF-8
-      self.encode('UTF-8').force_encoding('ASCII-8BIT')
+      begin
+        self.encode('UTF-8').force_encoding('ASCII-8BIT')
+      rescue Encoding::UndefinedConversionError
+        self
+      end
     else
       self
     end


### PR DESCRIPTION
This patch makes searching for "(objectclass=user)" on my ActiveDirectory behave itself.  Something in the LDAP directory was failing terribly, which was allowing searches by "(cn=[a-z]*)", but would fail on a filter for "(objectclass=user)".

This quick'n'dirty patch resolved my issue.

I use it in combination with Pull Request 33 (https://github.com/ruby-ldap/ruby-net-ldap/pull/33).
