### PR TITLE
UTF-8 encoding fix.

### DIFF
--- a/lib/net/ber/core_ext/string.rb
+++ b/lib/net/ber/core_ext/string.rb
@@ -20,7 +20,8 @@ module Net::BER::Extensions::String
     if self.respond_to?(:encode)
       # Strings should be UTF-8 encoded according to LDAP.
       # However, the BER code is not necessarily valid UTF-8
-      self.encode('UTF-8').force_encoding('ASCII-8BIT')
+      #self.encode('UTF-8').force_encoding('ASCII-8BIT')
+			self.encode('UTF-8', invalid: :replace, undef: :replace, replace: '' ).force_encoding('ASCII-8BIT')
     else
       self
     end


### PR DESCRIPTION
I was having an issue where the AD server was sending back bad utf-8 code ( \x82 I believe was the code value ).  I'm currently using this fix in a production scenario.  I would love to get some feedback on if this is a valid fix.
