### PR TITLE
Unescape escaped filter characters in #to_ber

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -291,11 +291,11 @@ class Net::LDAP::Filter
           case b.ber_identifier
           when 0x80 # context-specific primitive 0, SubstringFilter "initial"
             raise Net::LDAP::LdapError, "Unrecognized substring filter; bad initial value." if str.length > 0
-            str += b
+            str += escape(b)
           when 0x81 # context-specific primitive 0, SubstringFilter "any"
-            str += "*#{b}"
+            str += "*#{escape(b)}"
           when 0x82 # context-specific primitive 0, SubstringFilter "final"
-            str += "*#{b}"
+            str += "*#{escape(b)}"
             final = true
           end
         }
@@ -509,17 +509,17 @@ class Net::LDAP::Filter
           first = nil
           ary.shift
         else
-          first = ary.shift.to_ber_contextspecific(0)
+          first = unescape(ary.shift).to_ber_contextspecific(0)
         end
 
         if ary.last.empty?
           last = nil
           ary.pop
         else
-          last = ary.pop.to_ber_contextspecific(2)
+          last = unescape(ary.pop).to_ber_contextspecific(2)
         end
 
-        seq = ary.map { |e| e.to_ber_contextspecific(1) }
+        seq = ary.map { |e| unescape(e).to_ber_contextspecific(1) }
         seq.unshift first if first
         seq.push last if last
 


### PR DESCRIPTION
When searching for attribute values that contain asterisks or backslashes, the search results are empty when they should not be.

For example I have an Active Directory group with `cn` value of `special*group`.  A search with filter `Net::LDAP::Filter.begins(:cn, "special*g")` should find this group, but doesn't.

I compared Wireshark captures of this query with one using the `ldapsearch` command line tool.  The bytes sent on the wire by `ldapsearch ... '(cn=special\2Ag*)'`, have a single `0x2a` byte (the hex value of the asterisk character) between `special` and `g`, whereas the net-ldap gem sends three bytes, one for `\`, one for `2`, and one for `A`.

This pull request uses the `unescape` method to make the net-ldap gem behave like `ldapsearch`, and causes my search to return the expected results.  However, I wonder if the net-ldap gem doesn't already work this way to prevent existing client code from breaking due to unexpected unescaping.  If so, what workaround would solve my problem?

When the `unescape` method [was introduced](https://github.com/ruby-ldap/ruby-net-ldap/commit/089abcceb24cb9315e9edcdfbff397add7062f7b), the `#to_ber` method was updated to use `unescape` in some places.  This pull request updates `#to_ber` to use `unescape` a few more times.  I'm curious if there is a reason the previous commit decided not to use `unescape` where this pull request adds it.
