### PR TITLE
Fixes an error when following referrals

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1481,7 +1481,7 @@ class Net::LDAP::Connection #:nodoc:
         when 5 # search-result
           result_pdu = pdu
           controls = pdu.result_controls
-          if return_referrals && result_code == 10
+          if return_referrals && pdu.result_code == 10
             if block_given?
               se = Net::LDAP::Entry.new
               se[:search_referrals] = (pdu.search_referrals || [])


### PR DESCRIPTION
When following referrals in search results an error
occurs due to an unreferrenced variable. The actual
value is on the pdu object.
