### PR TITLE
Moved VERSION into a single file

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -25,6 +25,7 @@ lib/net/ldap/entry.rb
 lib/net/ldap/filter.rb
 lib/net/ldap/password.rb
 lib/net/ldap/pdu.rb
+lib/net/ldap/version.rb
 lib/net/snmp.rb
 net-ldap.gemspec
 spec/integration/ssl_ber_spec.rb

--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -1,4 +1,6 @@
 # -*- ruby encoding: utf-8 -*-
+require 'net/ldap/version'
+
 module Net # :nodoc:
   ##
   # == Basic Encoding Rules (BER) Support Module
@@ -106,7 +108,7 @@ module Net # :nodoc:
   # <tr><th>BMPString</th><th>C</th><td>30: 62 (0x3e, 0b00111110)</td></tr>
   # </table>
   module BER
-    VERSION = '0.4.0'
+    VERSION = Net::LDAP::VERSION
 
     ##
     # Used for BER-encoding the length and content bytes of a Fixnum integer

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -23,6 +23,7 @@ require 'net/ldap/filter'
 require 'net/ldap/dataset'
 require 'net/ldap/password'
 require 'net/ldap/entry'
+require 'net/ldap/version'
 
 # == Quick-start for the Impatient
 # === Quick Example of a user-authentication against an LDAP directory:
@@ -241,7 +242,6 @@ require 'net/ldap/entry'
 # and then keeps it open while it executes a user-supplied block.
 # Net::LDAP#open closes the connection on completion of the block.
 class Net::LDAP
-  VERSION = "0.4.0"
 
   class LdapError < StandardError; end
 

--- a/lib/net/ldap/version.rb
+++ b/lib/net/ldap/version.rb
@@ -1,0 +1,5 @@
+module Net
+  class LDAP
+    VERSION = "0.4.0"
+  end
+end

--- a/lib/net/snmp.rb
+++ b/lib/net/snmp.rb
@@ -1,8 +1,10 @@
 # -*- ruby encoding: utf-8 -*-
+require 'net/ldap/version'
+
 # :stopdoc:
 module Net
     class SNMP
-      VERSION = '0.4.0'
+      VERSION = Net::LDAP::VERSION
 
 	AsnSyntax = Net::BER.compile_syntax({
 	    :application => {

--- a/net-ldap.gemspec
+++ b/net-ldap.gemspec
@@ -1,7 +1,11 @@
 # -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'net/ldap/version'
+
 Gem::Specification.new do |s|
   s.name = %q{net-ldap}
-  s.version = "0.4.0"
+  s.version = Net::LDAP::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Francis Cianfrocca", "Emiel van de Laar", "Rory O'Connell", "Kaspar Schiess", "Austin Ziegler"]


### PR DESCRIPTION
You can now update VERSION via just one file:
lib/net/ldap/version.rb

This makes maintenance easier.

PS:

I'm rather confused about if this is the official net-ldap github repository or not:
- [RubyGems](http://rubygems.org/gems/net-ldap) lists [Rory-O/ruby-netldap](https://github.com/RoryO/ruby-net-ldap) as the location of the source.
- [RubyForge](http://net-ldap.rubyforge.org/) points here, but is version 0.2.2
- [netldap.org](https://github.com/ruby-ldap/ruby-net-ldap) points here.

To add to the confusion, I don't see version 0.3.1 in this repository but maybe I missed it?
