### PR TITLE
Many specific exceptions instead of one LdapError

### DIFF
--- a/lib/net/ldap/entry.rb
+++ b/lib/net/ldap/entry.rb
@@ -71,7 +71,7 @@ class Net::LDAP::Entry
 
       return nil if ds.empty?
 
-      raise Net::LDAP::LdapError, "Too many LDIF entries" unless ds.size == 1
+      raise Net::LDAP::EntryOverflowError, "Too many LDIF entries" unless ds.size == 1
 
       entry = ds.to_entries.first
 

--- a/lib/net/ldap/password.rb
+++ b/lib/net/ldap/password.rb
@@ -29,7 +29,7 @@ class Net::LDAP::Password
             srand; salt = (rand * 1000).to_i.to_s 
             attribute_value = '{SSHA}' + Base64.encode64(Digest::SHA1.digest(str + salt) + salt).chomp!
          else
-            raise Net::LDAP::LdapError, "Unsupported password-hash type (#{type})"
+            raise Net::LDAP::HashTypeUnsupportedError, "Unsupported password-hash type (#{type})"
          end
       return attribute_value
     end

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -9,11 +9,11 @@ class TestFilter < Test::Unit::TestCase
   end
 
   def test_invalid_filter_string
-    assert_raises(Net::LDAP::LdapError) { Filter.from_rfc2254("") }
+    assert_raises(Net::LDAP::FilterSyntaxInvalidError) { Filter.from_rfc2254("") }
   end
 
   def test_invalid_filter
-    assert_raises(Net::LDAP::LdapError) {
+    assert_raises(Net::LDAP::OperatorError) {
       # This test exists to prove that our constructor blocks unknown filter
       # types. All filters must be constructed using helpers.
       Filter.__send__(:new, :xx, nil, nil)


### PR DESCRIPTION
We need to rescue some exceptions, but because there is only one LdapError-class, we cannot rescue one specific behavior.
So i wrote this patch for using many LdapError-classes but specific exceptions.
All of these exceptions has LdapError as base-class, so it do not break any exception handling.