### PR TITLE
Catch Encoding::ConverterNotFoundError

### DIFF
--- a/lib/net/ber/core_ext/string.rb
+++ b/lib/net/ber/core_ext/string.rb
@@ -32,6 +32,8 @@ module Net::BER::Extensions::String
         self.encode('UTF-8').force_encoding('ASCII-8BIT')
       rescue Encoding::UndefinedConversionError
         self
+      rescue Encoding::ConverterNotFoundError
+        return self
       end
     else
       self


### PR DESCRIPTION
Stumbled across this error, while performing and LDAP search on a Microsoft Active Directory 2008 RC2 (AD).

This specific installation had been migrated form why back when (NT times).

In this case some binary data was being returned, which caused a "Encoding::ConverterNotFoundError" error to be thrown. Catching this error and returning self instead of trying to encode to "UTF-8" provides a workaround for the problem.

Unfortunately the AD in question doesn't belong to me, so I can't give you more specifics on the data returned. 

This is the reason why I was unable to provide a test case for this fix. 

Signed-off-by: Jason Franklin franklin@equinux.com
