### PR TITLE
Don't change the encoding of binary data to UTF-8.

### DIFF
--- a/lib/net/ber/core_ext/string.rb
+++ b/lib/net/ber/core_ext/string.rb
@@ -25,7 +25,7 @@ module Net::BER::Extensions::String
 	end
 
   def raw_utf8_encoded
-    if self.respond_to?(:encode)
+    if self.respond_to?(:encode) && self.encoding.to_s != 'ASCII-8BIT'
       # Strings should be UTF-8 encoded according to LDAP.
       # However, the BER code is not necessarily valid UTF-8
       begin


### PR DESCRIPTION
It does not make sense to change the encoding of binary data, i.e., data that
already has the encoding of ASCII-8BIT or BINARY. Data stored in the jpegPhoto
attribute is an example.

irb(main):001:0> binstring = ['FFD8FFE000104A46494600'].pack('H*')
=> "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00"
irb(main):002:0> binstring.encoding
=> #Encoding:ASCII-8BIT
irb(main):003:0> binstring.respond_to?(:encode)
=> true
irb(main):004:0> binstring.encode('UTF-8')
Encoding::UndefinedConversionError: "\xFF" from ASCII-8BIT to UTF-8
        from (irb):4:in `encode'
        from (irb):4
        from /usr/bin/irb:12:in`<main>'
irb(main):005:0>
