### PR TITLE
FilterParser can parse filter string including special chars.

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -755,7 +755,7 @@ class Net::LDAP::Filter
         scanner.scan(/\s*/)
         if op = scanner.scan(/<=|>=|!=|:=|=/)
           scanner.scan(/\s*/)
-          if value = scanner.scan(/(?:[-\w*.+@=,#\$%&!'\s\xC3\x80-\xCA\xAF]|[^\x00-\x7F]|\\[a-fA-F\d]{2})+/u)
+          if value = scanner.scan(/(?:[-\[\]{}\w*.+@=,#\$%&!'^~\s\xC3\x80-\xCA\xAF]|[^\x00-\x7F]|\\[a-fA-F\d]{2})+/u)
             # 20100313 AZ: Assumes that "(uid=george*)" is the same as
             # "(uid=george* )". The standard doesn't specify, but I can find
             # no examples that suggest otherwise.

--- a/spec/unit/ldap/filter_parser_spec.rb
+++ b/spec/unit/ldap/filter_parser_spec.rb
@@ -6,12 +6,23 @@ describe Net::LDAP::Filter::FilterParser do
   describe "#parse" do
     context "Given ASCIIs as filter string" do
       let(:filter_string) { "(cn=name)" }
+
       specify "should generate filter object" do
         expect(Net::LDAP::Filter::FilterParser.parse(filter_string)).to be_a Net::LDAP::Filter
       end
     end
+
     context "Given string including multibyte chars as filter string" do
       let(:filter_string) { "(cn=名前)" }
+
+      specify "should generate filter object" do
+        expect(Net::LDAP::Filter::FilterParser.parse(filter_string)).to be_a Net::LDAP::Filter
+      end
+    end
+
+    context 'Given string including special chars allowd to be used in DN as filter string' do
+      let(:filter_string) { '(cn=[{^something~}])' }
+
       specify "should generate filter object" do
         expect(Net::LDAP::Filter::FilterParser.parse(filter_string)).to be_a Net::LDAP::Filter
       end


### PR DESCRIPTION
FilterParser could not parse a given string like `(cn=[{something}])` . this pull-request provides a patch to fix this problem. 
## Reference
- [Characters to Escape](http://www.rlmueller.net/CharactersEscaped.htm)
