### PR TITLE
colons are ':' valid filter characters

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -755,7 +755,7 @@ class Net::LDAP::Filter
         scanner.scan(/\s*/)
         if op = scanner.scan(/<=|>=|!=|:=|=/)
           scanner.scan(/\s*/)
-          if value = scanner.scan(/(?:[-\w*.+@=,#\$%&!'\s\xC3\x80-\xCA\xAF]|[^\x00-\x7F]|\\[a-fA-F\d]{2})+/u)
+          if value = scanner.scan(/(?:[-\w*.+:@=,#\$%&!'\s\xC3\x80-\xCA\xAF]|[^\x00-\x7F]|\\[a-fA-F\d]{2})+/u)
             # 20100313 AZ: Assumes that "(uid=george*)" is the same as
             # "(uid=george* )". The standard doesn't specify, but I can find
             # no examples that suggest otherwise.

--- a/spec/unit/ldap/filter_parser_spec.rb
+++ b/spec/unit/ldap/filter_parser_spec.rb
@@ -16,5 +16,11 @@ describe Net::LDAP::Filter::FilterParser do
         expect(Net::LDAP::Filter::FilterParser.parse(filter_string)).to be_a Net::LDAP::Filter
       end
     end
+    context "Given string including colons ':'" do
+      let(:filter_string) { "(ismemberof=cn=edu:berkeley:app:calmessages:deans,ou=campus groups,dc=berkeley,dc=edu)" }
+      specify "should generate filter object" do
+        expect(Net::LDAP::Filter::FilterParser.parse(filter_string)).to be_a Net::LDAP::Filter
+      end
+    end
   end
 end


### PR DESCRIPTION
ruby-net-ldap is choking on queries that work with our university LDAP using the `ldapsearch` utility.  Here is an example of such a query:

``` bash
ldapsearch -H ldaps://ldap.berkeley.edu -x -D "<bind>" -W -s sub -b "ou=people,dc=berkeley,dc=edu" "(&(objectclass=person)(ismemberof=cn=edu:berkeley:app:calmessages:deans,ou=campus groups,dc=berkeley,dc=edu))" "uid"
```

In this case, ruby-net-ldap would raise `Net::LDAP::LdapError: Invalid filter syntax`

I've also run this query using the python ldap library and like `ldapsearch` it works fine.

While debugging this I isolated the problem down to the parse_filter_branch method: the scanner doesn't include ':'  in its regex when--I believe--it should.  After updating the regex everything worked as expected for me.  Please let me know if you have any questions.
