### PR TITLE
Use 16 bytes secure random instead of a number from 0 to 999.  This

### DIFF
--- a/lib/net/ldap/password.rb
+++ b/lib/net/ldap/password.rb
@@ -2,6 +2,7 @@
 require 'digest/sha1'
 require 'digest/md5'
 require 'base64'
+require 'securerandom'
 
 class Net::LDAP::Password
   class << self
@@ -26,7 +27,7 @@ class Net::LDAP::Password
          when :sha
             attribute_value = '{SHA}' + Base64.encode64(Digest::SHA1.digest(str)).chomp! 
          when :ssha
-            srand; salt = (rand * 1000).to_i.to_s 
+	    salt = SecureRandom.random_bytes(16)
             attribute_value = '{SSHA}' + Base64.encode64(Digest::SHA1.digest(str + salt) + salt).chomp!
          else
             raise Net::LDAP::LdapError, "Unsupported password-hash type (#{type})"


### PR DESCRIPTION
increases entropy in the salt from about 10 bits to 128 bits.

Reported by:    Pierre Carrier <pierre carrier#airbnb com>
Security:   CVE-2014-0083
