### PR TITLE
Better SSHA salt

### DIFF
--- a/lib/net/ldap/password.rb
+++ b/lib/net/ldap/password.rb
@@ -2,7 +2,7 @@
 require 'digest/sha1'
 require 'digest/md5'
 require 'base64'
-require 'secure_random'
+require 'securerandom'
 
 class Net::LDAP::Password
   class << self


### PR DESCRIPTION
1000 possible salts is way too few to provide any protection. Also, `srand` in older versions of Ruby doesn't use hardware entropy sources.

/cc @dbussink
