### PR TITLE
Fixed InvalidByteSequenceError exception handling

### DIFF
--- a/lib/net/ber/core_ext/string.rb
+++ b/lib/net/ber/core_ext/string.rb
@@ -33,7 +33,9 @@ module Net::BER::Extensions::String
       rescue Encoding::UndefinedConversionError
         self
       rescue Encoding::ConverterNotFoundError
-        return self
+        self
+      rescue Encoding::InvalidByteSequenceError
+        self
       end
     else
       self


### PR DESCRIPTION
(Done with @perlun)

We ran into this exception in a customer environment. Unclear exactly why, but here is the stack trace. Adding the rescue clause here _seems_ to work quite OK...

OK to merge?

```
Hash: ""\xC3"" on ASCII-8BIT
  org/jruby/RubyString.java:7597:in `encode'
  net/ber/core_ext/string.rb:32:in `raw_utf8_encoded'
    self.encode('UTF-8').force_encoding('ASCII-8BIT')
  net/ber/core_ext/string.rb:15:in `to_ber'
    raw_string = raw_utf8_encoded
  net/ldap/filter.rb:528:in `to_ber'
    [@left.to_s.to_ber, unescape(@right).to_ber].to_ber_contextspecific(3)
  net/ldap.rb:1449:in `search'
    request = [
```
