### PR TITLE
Update respond_to? for Ruby 2.0

### DIFF
--- a/lib/net/ldap/entry.rb
+++ b/lib/net/ldap/entry.rb
@@ -147,7 +147,7 @@ class Net::LDAP::Entry
     Net::LDAP::Dataset.from_entry(self).to_ldif_string
   end
 
-  def respond_to?(sym) #:nodoc:
+  def respond_to?(sym, include_all = false) #:nodoc:
     return true if valid_attribute?(self.class.attribute_name(sym))
     return super
   end


### PR DESCRIPTION
Marshal.dump will choke on the attempt to serialize an LDAP::Entry. This change fixes that by updating the signature of respond_to? to Ruby 2.0 level.
