### PR TITLE
Fixed InvalidByteSequenceError exception handling

### DIFF
--- a/lib/net/ber/core_ext/string.rb
+++ b/lib/net/ber/core_ext/string.rb
@@ -33,7 +33,9 @@ module Net::BER::Extensions::String
       rescue Encoding::UndefinedConversionError
         self
       rescue Encoding::ConverterNotFoundError
-        return self
+        self
+      rescue Encoding::InvalidByteSequenceError
+        self
       end
     else
       self


### PR DESCRIPTION
This is a new attempt at #88, which can now be closed (this one replaces it).
