### PR TITLE
Bump master to 0.7.0

### DIFF
--- a/lib/net/ldap/version.rb
+++ b/lib/net/ldap/version.rb
@@ -1,5 +1,5 @@
 module Net
   class LDAP
-    VERSION = "0.6.1"
+    VERSION = "0.7.0"
   end
 end


### PR DESCRIPTION
Looks like `master` is out-of-sync from the `v0.7.0` tag. This merges in the commit that updates the version.

Aside, I'm using a tool that depends on `git describe` to generate a work-in-progress gem for rapid iteration, and it currently returns `v0.6.1` since this commit is missing. `git describe` _should_ return `v0.7.0` once this is merged.
