### PR TITLE
Allow failures for jruby 1.9 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ rvm:
   - 2.0.0
   - jruby-19mode
   - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: jruby-19mode
 script: bundle exec rake spec


### PR DESCRIPTION
Currently, JRuby 1.9 builds always fail. This branch attempts to mark those builds as "allowed to fail" according to the [Travis CI docs](http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail).

This could be removed once the JRuby tests are fixed.
