### PR TITLE
Fix spec deprecations

### DIFF
--- a/spec/unit/ber/ber_spec.rb
+++ b/spec/unit/ber/ber_spec.rb
@@ -90,8 +90,7 @@ describe "BER encoding of" do
 					raw_string("\x04\x10" + "j1\xB4\xA1*\xA2zA\xAC\xA9`?'\xDDQ\x16")
 			end
       it "should not fail on strings that can not be converted to UTF-8" do
-        error = Encoding::UndefinedConversionError
-        lambda {"\x81".to_ber }.should_not raise_exception(error)
+        expect { "\x81".to_ber }.not_to raise_error
       end
     end
   end
@@ -120,21 +119,21 @@ describe Net::BER::BerIdentifiedString do
     context "binary data" do
       let(:data) { ["6a31b4a12aa27a41aca9603f27dd5116"].pack("H*").force_encoding("ASCII-8BIT") }
 
-      its(:valid_encoding?) { should be_true }
+      specify { subject.valid_encoding?.should == true }
       specify { subject.encoding.name.should == "ASCII-8BIT" }
     end
 
     context "ascii data in UTF-8" do
       let(:data) { "some text".force_encoding("UTF-8") }
 
-      its(:valid_encoding?) { should be_true }
+      specify { subject.valid_encoding?.should == true }
       specify { subject.encoding.name.should == "UTF-8" }
     end
 
     context "UTF-8 data in UTF-8" do
       let(:data) { ["e4b8ad"].pack("H*").force_encoding("UTF-8") }
-      
-      its(:valid_encoding?) { should be_true }
+
+      specify { subject.valid_encoding?.should == true }
       specify { subject.encoding.name.should == "UTF-8" }
     end
   end

--- a/spec/unit/ldap/search_spec.rb
+++ b/spec/unit/ldap/search_spec.rb
@@ -23,7 +23,7 @@ describe Net::LDAP, "search method" do
   context "when :return_result => false" do
     it "should return false upon error" do
       result = @connection.search(:return_result => false)
-      result.should be_false
+      result.should == false
     end
   end
 

--- a/spec/unit/ldap_spec.rb
+++ b/spec/unit/ldap_spec.rb
@@ -23,10 +23,10 @@ describe Net::LDAP do
         bind_result = flexmock(:bind_result, :success? => true)
         @connection.should_receive(:bind).with(Hash).and_return(bind_result)
 
-        subject.bind.should be_true
+        subject.bind.should == true
 
         payload, result = events.pop
-        result.should be_true
+        result.should == true
         payload[:bind].should == bind_result
       end
 
@@ -38,7 +38,7 @@ describe Net::LDAP do
                     yields(entry = Net::LDAP::Entry.new("uid=user1,ou=users,dc=example,dc=com")).
                     and_return(flexmock(:search_result, :success? => true, :result_code => 0))
 
-        subject.search(:filter => "(uid=user1)").should be_true
+        subject.search(:filter => "(uid=user1)").should_not be_nil
 
         payload, result = events.pop
         result.should == [entry]


### PR DESCRIPTION
This pull request fixes the deprecation warnings from running `bundle exec rake`. Rather than add an additional dependency for `rspec-its`, I rewrote 3 of the specs to have the same meaning without the `its` syntax.

```
Deprecation Warnings:

Use of rspec-core's `its` method is deprecated. Use the rspec-its gem instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ber/ber_spec.rb:123:in `block (3 levels) in <top (required)>'.
Use of rspec-core's `its` method is deprecated. Use the rspec-its gem instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ber/ber_spec.rb:130:in `block (3 levels) in <top (required)>'.
Use of rspec-core's `its` method is deprecated. Use the rspec-its gem instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ber/ber_spec.rb:137:in `block (3 levels) in <top (required)>'.

`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ldap/search_spec.rb:26:in `block (3 levels) in <top (required)>'.

`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ber/ber_spec.rb:123:in `block (4 levels) in <top (required)>'.
`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ber/ber_spec.rb:130:in `block (4 levels) in <top (required)>'.
`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ber/ber_spec.rb:137:in `block (4 levels) in <top (required)>'.
Too many uses of deprecated '`be_true`'. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output.

`expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /Users/jch/projects/ruby-net-ldap/spec/unit/ber/ber_spec.rb:94:in `block (3 levels) in <top (required)>'.
```
