### PR TITLE
Remove redundant spec/spec.opts

### DIFF
--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,2 +1,0 @@
---format specdoc
---colour


### PR DESCRIPTION
There is a `.rspec` in the root directory with test options already. Remove the older rspec spec.opts file.
