### PR TITLE
Bring back Net::LDAP::Entry tests

### DIFF
--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -13,12 +13,6 @@ class TestEntry < Test::Unit::TestCase
     assert_equal [], @entry['sn']
   end
 
-  def test_empty_attribute_by_method
-    skip "Net::LDAP::Entry#valid_attribute? requires an attribute to be defined first"
-    # What is the valid encoding for attribute names?
-    assert_equal [], @entry.sn
-  end
-
   def test_attribute_assignment
     @entry['sn'] = 'Jensen'
     assert_equal ['Jensen'], @entry['sn']


### PR DESCRIPTION
This PR uncomments entry tests and updates them to minitest. I removed tests related to https://github.com/ruby-ldap/ruby-net-ldap/issues/117 until more clarification. This is a translation of existing tests, and does not add additional coverage.
