### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
-spec/ldap.yml
-.rvmrc
-*.gemspec
-pkg/
+*~
 *.swp
-html/
+.rvmrc
+pkg/
 doc/
 publish/
-coverage/
-coverage.info
-.rake_tasks~
 Gemfile.lock


### PR DESCRIPTION
- gemspec is useful information we should include with the published gem
- coverage isn't run anymore
- more aggressive blob for emacs and vim backup files
- rspec is going away with #121 
