### PR TITLE
Search integration tests

### DIFF
--- a/test/integration/test_search.rb
+++ b/test/integration/test_search.rb
@@ -66,12 +66,12 @@ class TestSearchIntegration < LDAPIntegrationTestCase
   def test_search_with_size
     entries = []
 
-    result = @ldap.search(filter: "(uid=user1)", base: "dc=rubyldap,dc=com", size: 1) do |entry|
+    result = @ldap.search(base: "dc=rubyldap,dc=com", size: 1) do |entry|
       assert_kind_of Net::LDAP::Entry, entry
       entries << entry
     end
 
-    refute entries.empty?
+    assert_equal 1, result.size
     assert_equal entries, result
   end
 end


### PR DESCRIPTION
WIP for adding more integration tests around search.
- [x] with restricted attributes
- [x] with filter string
- [x] with filter object
- [x] with size limit (failing test)
- [x] attributes_only
- [ ] deref (don't know how to test this)
- [ ] scope (needs additional fixtures)

cc @mtodd @schaary 
