### PR TITLE
Prioritize reads from queue by message ID

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -518,6 +518,14 @@ class Net::LDAP::Connection #:nodoc:
 
       result_pdu || OpenStruct.new(:status => :failure, :result_code => 1, :message => "Invalid search")
     end # instrument
+  ensure
+    # clean up message queue for this search
+    messages = message_queue.delete(message_id)
+
+    unless messages.empty?
+      instrument "search_messages_unread.net_ldap_connection",
+                 message_id: message_id, messages: messages
+    end
   end
 
   MODIFY_OPERATIONS = { #:nodoc:

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -199,6 +199,7 @@ class TestLDAPConnectionInstrumentation < Test::Unit::TestCase
                                           and_return(search_result)
 
     events = @service.subscribe "search.net_ldap_connection"
+    unread = @service.subscribe "search_messages_unread.net_ldap_connection"
 
     result = @connection.search(filter: "(uid=user1)")
     assert result.success?, "should be success"
@@ -209,5 +210,8 @@ class TestLDAPConnectionInstrumentation < Test::Unit::TestCase
     assert payload.has_key?(:filter)
     assert_equal "(uid=user1)", payload[:filter].to_s
     assert result
+
+    # ensure no unread
+    assert unread.empty?, "should not have any leftover unread messages"
   end
 end


### PR DESCRIPTION
This is an an alternative proposal (compared to https://github.com/ruby-ldap/ruby-net-ldap/issues/136) for the issues defined in https://github.com/ruby-ldap/ruby-net-ldap/pull/133. It aims for minimal changes to provide for correctness. The changes here are local to `Net::LDAP::Connection#search` but could be moved to `Net::LDAP::Connection#read` instead.

Thoughts?

NOTE: This is targeting the `open-integration-tests` branch since it was branched from there for testing/development.

cc @jch @schaary 
