### PR TITLE
Update ruby requirement >= 1.9.3

### DIFF
--- a/net-ldap.gemspec
+++ b/net-ldap.gemspec
@@ -32,7 +32,6 @@ the most recent LDAP RFCs (4510-4519, plutions of 4520-4532).}
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
   s.rubygems_version = %q{1.5.2}
   s.summary = %q{Net::LDAP for Ruby (also called net-ldap) implements client access for the Lightweight Directory Access Protocol (LDAP), an IETF standard protocol for accessing distributed directory services}
-  s.test_files = ["test/test_entry.rb", "test/test_filter.rb", "test/test_ldap_connection.rb", "test/test_ldif.rb", "test/test_password.rb", "test/test_rename.rb", "test/test_snmp.rb"]
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
In the next release:
- require ruby >= 1.9.3
- remove reference to dead rubyforge
- remove duplicate test_files gemspec reference

cc @schaary @mtodd
