### PR TITLE
Support querying ActiveDirectory capabilities when searching root dse

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1197,6 +1197,7 @@ class Net::LDAP
                 :attributes => [
                   :altServer,
                   :namingContexts,
+                  :supportedCapabilities,
                   :supportedControl,
                   :supportedExtension,
                   :supportedFeatures,


### PR DESCRIPTION
This PR adds `supportedCapabilities` to list of attributes to fetch when querying the root dse.

edit: I did not add a test for this since we do not currently have ActiveDirectory integration tests. Also going to include this in 0.9.0.

cc @mtodd @schaary 
