### PR TITLE
Fix test_unresponsive_host

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -17,6 +17,8 @@ class Net::LDAP::Connection #:nodoc:
       raise Net::LDAP::LdapError, "Server #{server[:host]} refused connection on port #{server[:port]}."
     rescue Errno::EHOSTUNREACH => error
       raise Net::LDAP::LdapError, "Host #{server[:host]} was unreachable (#{error.message})"
+    rescue Errno::ETIMEDOUT
+      raise Net::LDAP::LdapError, "Connection to #{server[:host]} timed out."
     end
 
     if server[:encryption]


### PR DESCRIPTION
While working on my TLS options and running the tests, I noticed that this test failed.

When the host doesn't respond, the correct exception is thrown now.
