### PR TITLE
Bug fixes to 0.9.0

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -562,12 +562,13 @@ class Net::LDAP::Connection #:nodoc:
       result_pdu || OpenStruct.new(:status => :failure, :result_code => Net::LDAP::ResultCodeOperationsError, :message => "Invalid search")
     end # instrument
   ensure
+
     # clean up message queue for this search
     messages = message_queue.delete(message_id)
 
     # in the exceptional case some messages were *not* consumed from the queue,
     # instrument the event but do not fail.
-    unless messages.empty?
+    unless messages.nil? or messages.empty?
       instrument "search_messages_unread.net_ldap_connection",
                  message_id: message_id, messages: messages
     end

--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -644,10 +644,18 @@ class Net::LDAP::Filter
   end
 
   ##
-  # Converts escaped characters (e.g., "\\28") to unescaped characters
+  # If the argument is a string, converts escaped characters (e.g., "\\28") to unescaped characters.
+  # If the argument is a number, just return as-is.
+  # Otherwise, an exception is thrown and the rhs argument is rejected.
   # ("(").
   def unescape(right)
-    right.gsub(/\\([a-fA-F\d]{2})/) { [$1.hex].pack("U") }
+    if defined? right.gsub
+      right.gsub(/\\([a-fA-F\d]{2})/) { [$1.hex].pack("U") }
+    elsif right.is_a? Fixnum
+      right.to_s
+    else
+      raise ArgumentError, "Did not know how to convert argument \"#{right}\" into the rhs of an LDAP filter"
+    end
   end
   private :unescape
 


### PR DESCRIPTION
Hey, I just fixed up a couple of the little issues I had when I tried to use your gem out-of-the-box. For what it's worth, it's entirely possible that I only encountered the nil-checking bug because one of my co-workers was messing around with our LDAP server while I was composing and testing my search query, it might not be a problem when working with an operational server.

Implemented a couple of bug fixes:
  * Connection#search now does more graceful nil-checking in its ensure clause, reducing cryptic crash messages
  * Filter class methods should now be able to gracefully accept numeric literals as filter rhs values