### PR TITLE
Support for rfc3062 Password Modify, closes #163

### DIFF
--- a/Contributors.rdoc
+++ b/Contributors.rdoc
@@ -22,3 +22,4 @@ Contributions since:
 * David J. Lee (DavidJLee)
 * Cody Cutrer (ccutrer)
 * WoodsBagotAndreMarquesLee
+* Rufus Post (mynameisrufus)

--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -106,6 +106,7 @@ module Net # :nodoc:
   # <tr><th>CHARACTER STRING</th><th>C</th><td>29: 61 (0x3d, 0b00111101)</td></tr>
   # <tr><th>BMPString</th><th>P</th><td>30: 30 (0x1e, 0b00011110)</td></tr>
   # <tr><th>BMPString</th><th>C</th><td>30: 62 (0x3e, 0b00111110)</td></tr>
+  # <tr><th>ExtendedResponse</th><th>C</th><td>107: 139 (0x8b, 0b010001011)</td></tr>
   # </table>
   module BER
     VERSION = Net::LDAP::VERSION

--- a/lib/net/ldap/pdu.rb
+++ b/lib/net/ldap/pdu.rb
@@ -74,6 +74,7 @@ class Net::LDAP::PDU
   attr_reader :search_referrals
   attr_reader :search_parameters
   attr_reader :bind_parameters
+  attr_reader :extended_response
 
   ##
   # Returns RFC-2251 Controls if any.
@@ -120,7 +121,7 @@ class Net::LDAP::PDU
     when UnbindRequest
       parse_unbind_request(ber_object[1])
     when ExtendedResponse
-      parse_ldap_result(ber_object[1])
+      parse_extended_response(ber_object[1])
     else
       raise LdapPduError.new("unknown pdu-type: #{@app_tag}")
     end
@@ -179,6 +180,29 @@ class Net::LDAP::PDU
     parse_search_referral(sequence[3]) if @ldap_result[:resultCode] == Net::LDAP::ResultCodeReferral
   end
   private :parse_ldap_result
+
+  ##
+  # Parse an extended response
+  #
+  # http://www.ietf.org/rfc/rfc2251.txt
+  #
+  # Each Extended operation consists of an Extended request and an
+  # Extended response.
+  #
+  #      ExtendedRequest ::= [APPLICATION 23] SEQUENCE {
+  #           requestName      [0] LDAPOID,
+  #           requestValue     [1] OCTET STRING OPTIONAL }
+
+  def parse_extended_response(sequence)
+    sequence.length >= 3 or raise Net::LDAP::PDU::Error, "Invalid LDAP result length."
+    @ldap_result = {
+      :resultCode => sequence[0],
+      :matchedDN => sequence[1],
+      :errorMessage => sequence[2]
+    }
+    @extended_response = sequence[3]
+  end
+  private :parse_extended_response
 
   ##
   # A Bind Response may have an additional field, ID [7], serverSaslCreds,

--- a/test/fixtures/openldap/slapd.conf.ldif
+++ b/test/fixtures/openldap/slapd.conf.ldif
@@ -3,7 +3,7 @@ objectClass: olcGlobal
 cn: config
 olcPidFile: /var/run/slapd/slapd.pid
 olcArgsFile: /var/run/slapd/slapd.args
-olcLogLevel: none
+olcLogLevel: -1
 olcToolThreads: 1
 
 dn: olcDatabase={-1}frontend,cn=config

--- a/test/integration/test_password_modify.rb
+++ b/test/integration/test_password_modify.rb
@@ -1,0 +1,80 @@
+require_relative '../test_helper'
+
+class TestPasswordModifyIntegration < LDAPIntegrationTestCase
+  def setup
+    super
+    @ldap.authenticate 'cn=admin,dc=rubyldap,dc=com', 'passworD1'
+
+    @dn = 'uid=modify-password-user1,ou=People,dc=rubyldap,dc=com'
+
+    attrs = {
+      objectclass: %w(top inetOrgPerson organizationalPerson person),
+      uid: 'modify-password-user1',
+      cn: 'modify-password-user1',
+      sn: 'modify-password-user1',
+      mail: 'modify-password-user1@rubyldap.com',
+      userPassword: 'passworD1'
+    }
+    unless @ldap.search(base: @dn, scope: Net::LDAP::SearchScope_BaseObject)
+      assert @ldap.add(dn: @dn, attributes: attrs), @ldap.get_operation_result.inspect
+    end
+    assert @ldap.search(base: @dn, scope: Net::LDAP::SearchScope_BaseObject)
+
+    @auth = {
+      method: :simple,
+      username: @dn,
+      password: 'passworD1'
+    }
+  end
+
+  def test_password_modify
+    assert @ldap.password_modify(dn: @dn,
+                                 auth: @auth,
+                                 old_password: 'passworD1',
+                                 new_password: 'passworD2')
+
+    assert @ldap.get_operation_result.extended_response.nil?,
+      'Should not have generated a new password'
+
+    refute @ldap.bind(username: @dn, password: 'passworD1', method: :simple),
+      'Old password should no longer be valid'
+
+    assert @ldap.bind(username: @dn, password: 'passworD2', method: :simple),
+      'New password should be valid'
+  end
+
+  def test_password_modify_generate
+    assert @ldap.password_modify(dn: @dn,
+                                 auth: @auth,
+                                 old_password: 'passworD1')
+
+    generated_password = @ldap.get_operation_result.extended_response[0][0]
+
+    assert generated_password, 'Should have generated a password'
+
+    refute @ldap.bind(username: @dn, password: 'passworD1', method: :simple),
+      'Old password should no longer be valid'
+
+    assert @ldap.bind(username: @dn, password: generated_password, method: :simple),
+      'New password should be valid'
+  end
+
+  def test_password_modify_generate_no_old_password
+    assert @ldap.password_modify(dn: @dn,
+                                 auth: @auth)
+
+    generated_password = @ldap.get_operation_result.extended_response[0][0]
+
+    assert generated_password, 'Should have generated a password'
+
+    refute @ldap.bind(username: @dn, password: 'passworD1', method: :simple),
+      'Old password should no longer be valid'
+
+    assert @ldap.bind(username: @dn, password: generated_password, method: :simple),
+      'New password should be valid'
+  end
+
+  def teardown
+    @ldap.delete dn: @dn
+  end
+end


### PR DESCRIPTION
This implements the password modify extended request
http://tools.ietf.org/html/rfc3062

Change existing password:

```ruby
dn = 'uid=modify-password-user1,ou=People,dc=rubyldap,dc=com'

auth = {
  method: :simple,
  username: dn,
  password: 'passworD1'
}

ldap.password_modify(
  dn: dn,
  auth: auth,
  old_password: 'passworD1',
  new_password: 'passworD2'
)
```

Or get the LDAP server to generate a password for you:

```ruby
dn = 'uid=modify-password-user1,ou=People,dc=rubyldap,dc=com'

auth = {
  method: :simple,
  username: dn,
  password: 'passworD1'
}

ldap.password_modify(
  dn: dn,
  auth: auth,
  old_password: 'passworD1'
)

ldap.get_operation_result.extended_response[0][0] #=> 'VtcgGf/G'
```