### PR TITLE
refactor connection establishment

### DIFF
--- a/Contributors.rdoc
+++ b/Contributors.rdoc
@@ -20,3 +20,4 @@ Contributions since:
 * Erik Hetzner (egh)
 * nowhereman
 * David J. Lee (DavidJLee)
+* Cody Cutrer (ccutrer)


### PR DESCRIPTION
reduces duplicated code, and makes it easier for future changes
to connection establishment because it's all in one place now
