### PR TITLE
Fix Travis CI build

### DIFF
--- a/script/install-openldap
+++ b/script/install-openldap
@@ -6,6 +6,7 @@ BASE_PATH="$( cd `dirname $0`/../test/fixtures/openldap && pwd )"
 SEED_PATH="$( cd `dirname $0`/../test/fixtures          && pwd )"
 
 dpkg -s slapd time ldap-utils gnutls-bin ssl-cert > /dev/null ||\
+  DEBIAN_FRONTEND=noninteractive sudo -E apt-get update  -y --force-yes && \
   DEBIAN_FRONTEND=noninteractive sudo -E apt-get install -y --force-yes slapd time ldap-utils gnutls-bin ssl-cert
 
 sudo /etc/init.d/slapd stop


### PR DESCRIPTION
gnutls-bin_3.0.11+really2.12.14-5ubuntu3.8_amd64.deb is gone from ubuntu repos, but travis attempts to download it. `apt-get update` should fix the issue.