### PR TITLE
Remove obsolete rbx-19mode from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.1.2
   # optional
   - jruby-19mode
-  - rbx-19mode
   - rbx-2
 
 env:


### PR DESCRIPTION
There are no language modes in Rubinius anymore. Using rbx-2 will run the most recent release of Rubinius 2.x.