### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1
+  - 2.2
   # optional
+  - ruby-head
   - jruby-19mode
+  - jruby-head
   - rbx-2
 
 env:
@@ -18,8 +21,9 @@ script: bundle exec rake ci
 
 matrix:
   allow_failures:
+    - rvm: ruby-head
     - rvm: jruby-19mode
-    - rvm: rbx-19mode
+    - rvm: jruby-head
     - rvm: rbx-2
   fast_finish: true
 

--- a/net-ldap.gemspec
+++ b/net-ldap.gemspec
@@ -32,4 +32,5 @@ the most recent LDAP RFCs (4510-4519, plutions of 4520-4532).}
   s.add_development_dependency("flexmock", "~> 1.3")
   s.add_development_dependency("rake", "~> 10.0")
   s.add_development_dependency("rubocop", "~> 0.28.0")
+  s.add_development_dependency("test-unit")
 end


### PR DESCRIPTION
…and another one PR about travis.
- Use ruby 2.1 instead of exact version 2.1.2
- Drop rbx-19mode
- Add ruby-2.2, ruby-head, jruby-head (last two are optional)

Feel free to reject this PR if this changes will be incorporated into other one.