### PR TITLE
Fixing incorrect error class name

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -652,7 +652,7 @@ class Net::LDAP::Connection #:nodoc:
     pdu = queued_read(message_id)
 
     if !pdu || pdu.app_tag != Net::LDAP::PDU::AddResponse
-      raise Net::LDAP::ResponseMissingError, "response missing or invalid"
+      raise Net::LDAP::ResponseMissingOrInvalidError, "response missing or invalid"
     end
 
     pdu


### PR DESCRIPTION
This line in `connection.rb` tries to raise `Net::LDAP::ResponseMissingError` but that class doesn't exist (so I instead get a `NameError`).

I can only assume that it should be **`ResponseMissingOrInvalidError`**, as that's used elsewhere in this class, so I changed it.