### PR TITLE
Server strings are always UTF-8

### DIFF
--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -296,9 +296,8 @@ end
 class Net::BER::BerIdentifiedString < String
   attr_accessor :ber_identifier
   def initialize args
+    args.force_encoding('UTF-8') if args.respond_to(:force_encoding)
     super args
-    # LDAP uses UTF-8 encoded strings
-    self.encode('UTF-8') if self.respond_to?(:encoding) rescue self
   end
 end
 


### PR DESCRIPTION
String values returned from an LDAP server are already encoded using UTF-8. Simple update the Ruby String so that it knows it's a UTF-8 value.