### PR TITLE
Correctly set BerIdentifiedString values to UTF-8 

### DIFF
--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -296,8 +296,11 @@ end
 class Net::BER::BerIdentifiedString < String
   attr_accessor :ber_identifier
   def initialize args
-    args.force_encoding('UTF-8') if args.respond_to(:force_encoding)
-    super args
+    super begin
+      args.respond_to?(:encode) ? args.encode('UTF-8') : args
+    rescue
+      args
+    end
   end
 end
 

--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -296,9 +296,8 @@ end
 class Net::BER::BerIdentifiedString < String
   attr_accessor :ber_identifier
   def initialize args
+    args.force_encoding('UTF-8') if args.respond_to(:force_encoding)
     super args
-    # LDAP uses UTF-8 encoded strings
-    self.encode('UTF-8') if self.respond_to?(:encoding) rescue self
   end
 end
 


### PR DESCRIPTION
The existing code did not set the actual internal value to UTF-8 when the encoding is correct. This patch attempts to resolve that problem by passing a UTF-8 encoded string to the super class when possible.