### PR TITLE
Raise Net::LDAP::ConnectionRefusedError when new connection is refused.

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -14,7 +14,7 @@ class Net::LDAP::Connection #:nodoc:
     rescue SocketError
       raise Net::LDAP::Error, "No such address or other socket error."
     rescue Errno::ECONNREFUSED
-      raise Net::LDAP::Error, "Server #{server[:host]} refused connection on port #{server[:port]}."
+      raise Net::LDAP::ConnectionRefusedError, "Server #{server[:host]} refused connection on port #{server[:port]}."
     rescue Errno::EHOSTUNREACH => error
       raise Net::LDAP::Error, "Host #{server[:host]} was unreachable (#{error.message})"
     rescue Errno::ETIMEDOUT

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -11,17 +11,18 @@ class Net::LDAP
   class SocketError < Error; end
   class ConnectionRefusedError < Error;
     def initialize(*args)
-      warn warning_message
+      warn_deprecation_message
       super
     end
 
     def message
-      warning_message + super
+      warn_deprecation_message
+      super
     end
 
     private
-    def warning_message
-      "Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead. \n"
+    def warn_deprecation_message
+      warn "Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead."
     end
   end
   class NoOpenSSLError < Error; end

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -9,7 +9,21 @@ class Net::LDAP
 
   class AlreadyOpenedError < Error; end
   class SocketError < Error; end
-  class ConnectionRefusedError < Error; end
+  class ConnectionRefusedError < Error;
+    def initialize(*args)
+      warn warning_message
+      super
+    end
+
+    def message
+      warning_message + super
+    end
+
+    private
+    def warning_message
+      "Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead. \n"
+    end
+  end
   class NoOpenSSLError < Error; end
   class NoStartTLSResultError < Error; end
   class NoSearchBaseError < Error; end

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -14,6 +14,13 @@ class TestLDAPConnection < Test::Unit::TestCase
     end
   end
 
+  def test_connection_refused
+    flexmock(TCPSocket).should_receive(:new).and_raise(Errno::ECONNREFUSED)
+    assert_raise Net::LDAP::ConnectionRefusedError do
+      Net::LDAP::Connection.new(:host => 'test.mocked.com', :port => 636)
+    end
+  end
+
   def test_raises_unknown_exceptions
     error = Class.new(StandardError)
     flexmock(TCPSocket).should_receive(:new).and_raise(error)

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -1,6 +1,14 @@
 require_relative 'test_helper'
 
 class TestLDAPConnection < Test::Unit::TestCase
+  def capture_stderr
+    stderr, $stderr = $stderr, StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = stderr
+  end
+
   def test_unresponsive_host
     assert_raise Net::LDAP::Error do
       Net::LDAP::Connection.new(:host => 'test.mocked.com', :port => 636)
@@ -16,9 +24,12 @@ class TestLDAPConnection < Test::Unit::TestCase
 
   def test_connection_refused
     flexmock(TCPSocket).should_receive(:new).and_raise(Errno::ECONNREFUSED)
-    assert_raise Net::LDAP::ConnectionRefusedError do
-      Net::LDAP::Connection.new(:host => 'test.mocked.com', :port => 636)
+    stderr = capture_stderr do
+      assert_raise Net::LDAP::ConnectionRefusedError do
+        Net::LDAP::Connection.new(:host => 'test.mocked.com', :port => 636)
+      end
     end
+    assert_equal("Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead.\n",  stderr)
   end
 
   def test_raises_unknown_exceptions


### PR DESCRIPTION
Now Net::LDAP::Connection.new raises Net::LDAP::Error even if the
connection refused.

It's hard for some application to reconnect it only when refused.