### PR TITLE
Specify the port of LDAP server by giving INTEGRATION_PORT

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,7 +56,7 @@ class LDAPIntegrationTestCase < Test::Unit::TestCase
     @service = MockInstrumentationService.new
     @ldap = Net::LDAP.new \
       host:           ENV.fetch('INTEGRATION_HOST', 'localhost'),
-      port:           389,
+      port:           ENV.fetch('INTEGRATION_PORT', 389),
       admin_user:     'uid=admin,dc=rubyldap,dc=com',
       admin_password: 'passworD1',
       search_domains: %w(dc=rubyldap,dc=com),


### PR DESCRIPTION
As #214 reported, the port number of LDAP server is hardcoded.  This PR allows to specify the port by giving as environment variable `INTEGRATION_PORT` as the comment `Rakefile` says. 

**CC:** @meastman 