### PR TITLE
Add the ability to provide a list of hosts for a connection

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -432,6 +432,7 @@ class Net::LDAP
 
   attr_accessor :host
   attr_accessor :port
+  attr_accessor :hosts
   attr_accessor :base
 
   # Instantiate an object of type Net::LDAP to perform directory operations.
@@ -440,6 +441,8 @@ class Net::LDAP
   # described below. The following arguments are supported:
   # * :host => the LDAP server's IP-address (default 127.0.0.1)
   # * :port => the LDAP server's TCP port (default 389)
+  # * :hosts => an enumerable of pairs of hosts and corresponding ports with
+  #   which to attempt opening connections (default [[host, port]])
   # * :auth => a Hash containing authorization parameters. Currently
   #   supported values include: {:method => :anonymous} and {:method =>
   #   :simple, :username => your_user_name, :password => your_password }
@@ -468,6 +471,7 @@ class Net::LDAP
   def initialize(args = {})
     @host = args[:host] || DefaultHost
     @port = args[:port] || DefaultPort
+    @hosts = args[:hosts]
     @verbose = false # Make this configurable with a switch on the class.
     @auth = args[:auth] || DefaultAuth
     @base = args[:base] || DefaultTreebase
@@ -1230,6 +1234,7 @@ class Net::LDAP
     Net::LDAP::Connection.new \
       :host                    => @host,
       :port                    => @port,
+      :hosts                   => @hosts,
       :encryption              => @encryption,
       :instrumentation_service => @instrumentation_service
   end

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -17,7 +17,7 @@ class TestLDAPConnection < Test::Unit::TestCase
             ]
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[0]).once.and_return(nil)
     flexmock(TCPSocket).should_receive(:new).ordered.never
-    Net::LDAP::Connection.new(:hosts => hosts.to_enum(:each))
+    Net::LDAP::Connection.new(:hosts => hosts)
   end
 
   def test_list_of_hosts_with_first_host_failure
@@ -29,7 +29,7 @@ class TestLDAPConnection < Test::Unit::TestCase
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[0]).once.and_raise(SocketError)
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[1]).once.and_return(nil)
     flexmock(TCPSocket).should_receive(:new).ordered.never
-    Net::LDAP::Connection.new(:hosts => hosts.to_enum(:each))
+    Net::LDAP::Connection.new(:hosts => hosts)
   end
 
   def test_list_of_hosts_with_all_hosts_failure
@@ -43,7 +43,7 @@ class TestLDAPConnection < Test::Unit::TestCase
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[2]).once.and_raise(SocketError)
     flexmock(TCPSocket).should_receive(:new).ordered.never
     assert_raise Net::LDAP::Error do
-      Net::LDAP::Connection.new(:hosts => hosts.to_enum(:each))
+      Net::LDAP::Connection.new(:hosts => hosts)
     end
   end
 


### PR DESCRIPTION
This change adds the ability to provide a list of hosts to try when opening a connection while maintaining backward compatibility with existing code.  If a list is provided, it overrides the individual host and port settings; otherwise, the individual settings are used as a single element list.

The host list is a simple object that responds to `each` and provides a hostname and port pair to a block.  This allows for users to use any mechanism they need to provide a list of potential hosts.  For instance, a randomized ordering for a static list could be used, or a list based on SRV record lookups could be provided.

In either case, failure of all servers is required in order to fail opening a connection.  A `Net::LDAP::Error` instance that summarizes all of the server failures is raised in this case.  If any server succeeds, usage proceeds as usual.  This includes setting up encryption if requested.