### PR TITLE
DRY up connection handling logic

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -48,14 +48,7 @@ class Net::LDAP::Connection #:nodoc:
       end
     end
 
-    if errors.size == 1
-      error = errors.first.first
-      raise Net::LDAP::ConnectionRefusedError, error.message if error.kind_of? Errno::ECONNREFUSED
-      raise Net::LDAP::Error, error.message
-    end
-
-    raise Net::LDAP::Error,
-      "Unable to connect to any given server: \n  #{errors.map { |e, h, p| "#{e.class}: #{e.message} (#{h}:#{p})" }.join("\n  ")}"
+    raise Net::LDAP::ConnectionError.new(errors)
   end
 
   module GetbyteForSSLSocket

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -34,14 +34,12 @@ class Net::LDAP::Connection #:nodoc:
     errors = []
     hosts.each do |host, port|
       begin
-        socket = TCPSocket.new(host, port)
-        prepare_socket(server.merge(socket: socket))
+        prepare_socket(server.merge(socket: TCPSocket.new(host, port)))
         return
       rescue Net::LDAP::Error, SocketError, SystemCallError,
              OpenSSL::SSL::SSLError => e
         # Ensure the connection is closed in the event a setup failure.
-        socket.close unless socket.nil?
-        socket = nil
+        close
         errors << [e, host, port]
       end
     end
@@ -145,6 +143,7 @@ class Net::LDAP::Connection #:nodoc:
   # have to call it, but perhaps it will come in handy someday.
   #++
   def close
+    return if @conn.nil?
     @conn.close
     @conn = nil
   end

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -43,8 +43,8 @@ class Net::LDAP::Connection #:nodoc:
         prepare_socket(server.merge(socket: TCPSocket.new(host, port)), true)
         return
       rescue Net::LDAP::Error, SocketError, SystemCallError,
-             OpenSSL::SSL::SSLError
-        errors << [$!, host, port]
+             OpenSSL::SSL::SSLError => e
+        errors << [e, host, port]
       end
     end
 

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -25,6 +25,25 @@ class Net::LDAP
       warn "Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead."
     end
   end
+  class ConnectionError < Error
+    def self.new(errors)
+      error = errors.first.first
+      if errors.size == 1
+        if error.kind_of? Errno::ECONNREFUSED
+          return Net::LDAP::ConnectionRefusedError.new(error.message)
+        end
+
+        return Net::LDAP::Error.new(error.message)
+      end
+
+      super
+    end
+
+    def initialize(errors)
+      message = "Unable to connect to any given server: \n  #{errors.map { |e, h, p| "#{e.class}: #{e.message} (#{h}:#{p})" }.join("\n  ")}"
+      super(message)
+    end
+  end
   class NoOpenSSLError < Error; end
   class NoStartTLSResultError < Error; end
   class NoSearchBaseError < Error; end

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -42,7 +42,7 @@ class TestLDAPConnection < Test::Unit::TestCase
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[1]).once.and_raise(SocketError)
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[2]).once.and_raise(SocketError)
     flexmock(TCPSocket).should_receive(:new).ordered.never
-    assert_raise Net::LDAP::Error do
+    assert_raise Net::LDAP::ConnectionError do
       Net::LDAP::Connection.new(:hosts => hosts)
     end
   end

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -11,10 +11,10 @@ class TestLDAPConnection < Test::Unit::TestCase
 
   def test_list_of_hosts_with_first_host_successful
     hosts = [
-              ['test.mocked.com', 636],
-              ['test2.mocked.com', 636],
-              ['test3.mocked.com', 636],
-            ]
+      ['test.mocked.com', 636],
+      ['test2.mocked.com', 636],
+      ['test3.mocked.com', 636],
+    ]
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[0]).once.and_return(nil)
     flexmock(TCPSocket).should_receive(:new).ordered.never
     Net::LDAP::Connection.new(:hosts => hosts)
@@ -22,10 +22,10 @@ class TestLDAPConnection < Test::Unit::TestCase
 
   def test_list_of_hosts_with_first_host_failure
     hosts = [
-              ['test.mocked.com', 636],
-              ['test2.mocked.com', 636],
-              ['test3.mocked.com', 636],
-            ]
+      ['test.mocked.com', 636],
+      ['test2.mocked.com', 636],
+      ['test3.mocked.com', 636],
+    ]
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[0]).once.and_raise(SocketError)
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[1]).once.and_return(nil)
     flexmock(TCPSocket).should_receive(:new).ordered.never
@@ -34,10 +34,10 @@ class TestLDAPConnection < Test::Unit::TestCase
 
   def test_list_of_hosts_with_all_hosts_failure
     hosts = [
-              ['test.mocked.com', 636],
-              ['test2.mocked.com', 636],
-              ['test3.mocked.com', 636],
-            ]
+      ['test.mocked.com', 636],
+      ['test2.mocked.com', 636],
+      ['test3.mocked.com', 636],
+    ]
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[0]).once.and_raise(SocketError)
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[1]).once.and_raise(SocketError)
     flexmock(TCPSocket).should_receive(:new).ordered.with(*hosts[2]).once.and_raise(SocketError)


### PR DESCRIPTION
This patch simplifies configuration of new connections and removes some duplicate code around setting up encryption.  However, it does change the exception messages somewhat.  All the same exception types are raised in all the same places, but mostly the messages of underlying exceptions that `Net::LDAP::Error` and `Net::LDAP::ConnectionRefusedError` effectively wrap are used directly rather than providing new, different messages.  These changes don't break any tests, but it's possible that some user of the library may depend on the specific messages currently produced.

The upshot of this change of exception messages will mostly be felt when users provide host lists.  If all given hosts fail, each failure message for each host is included in an exception summarizing all of the failures along with the original exception type and host parameters that triggered the failure message.  This will certainly help when debugging failures in the multiple host case.