### PR TITLE
Implement to_h method for entry

### DIFF
--- a/lib/net/ldap/entry.rb
+++ b/lib/net/ldap/entry.rb
@@ -155,6 +155,12 @@ class Net::LDAP::Entry
     Net::LDAP::Dataset.from_entry(self).to_ldif_string
   end
 
+  ##
+  # Converts the Entry to a Hash
+  def to_h
+    @myhash
+  end
+
   def respond_to?(sym, include_all = false) #:nodoc:
     return true if valid_attribute?(self.class.attribute_name(sym))
     return super

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -47,12 +47,17 @@ class TestEntryLDIF < Test::Unit::TestCase
       %Q{dn: something
 foo: foo
 barAttribute: bar
-      })
+})
   end
 
   def test_attribute
     assert_equal ['foo'], @entry.foo
     assert_equal ['foo'], @entry.Foo
+  end
+
+  def test_to_h
+    hash = {:dn => ['something'], foo: ['foo'], barattribute: ['bar']}
+    assert_equal hash, @entry.to_h
   end
 
   def test_modify_attribute


### PR DESCRIPTION
Hi guys!

I think it makes sense to have publicly available `to_h` method instead of dangerous `instance_variable_get` usage when we need actually hash, not an object, isn't it?