### PR TITLE
Lazy initialize Net::LDAP::Connection's internal socket

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1237,12 +1237,16 @@ class Net::LDAP
 
   # Establish a new connection to the LDAP server
   def new_connection
-    Net::LDAP::Connection.new \
+    connection = Net::LDAP::Connection.new \
       :host                    => @host,
       :port                    => @port,
       :hosts                   => @hosts,
       :encryption              => @encryption,
       :instrumentation_service => @instrumentation_service
+
+    # Force connect to see if there's a connection error
+    connection.socket
+    connection
   rescue Errno::ECONNREFUSED, Net::LDAP::ConnectionRefusedError => e
     @result = {
       :resultCode   => 52,

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1212,6 +1212,11 @@ class Net::LDAP
     inspected
   end
 
+  # Internal: Set @open_connection for testing
+  def connection=(connection)
+    @open_connection = connection
+  end
+
   private
 
   # Yields an open connection if there is one, otherwise establishes a new

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -13,6 +13,15 @@ class Net::LDAP::Connection #:nodoc:
     yield self if block_given?
   end
 
+  # Allows tests to parameterize what socket class to use
+  def socket_class
+    @socket_class || TCPSocket
+  end
+
+  def socket_class=(socket_class)
+    @socket_class = socket_class
+  end
+
   def prepare_socket(server)
     socket = server[:socket]
     encryption = server[:encryption]
@@ -28,7 +37,7 @@ class Net::LDAP::Connection #:nodoc:
     errors = []
     hosts.each do |host, port|
       begin
-        prepare_socket(server.merge(socket: TCPSocket.new(host, port)))
+        prepare_socket(server.merge(socket: socket_class.new(host, port)))
         return
       rescue Net::LDAP::Error, SocketError, SystemCallError,
              OpenSSL::SSL::SSLError => e

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -595,9 +595,8 @@ class Net::LDAP::Connection #:nodoc:
     pdu
   end
 
-  private
-
-  # Returns a Socket like object used internally to communicate with LDAP server
+  # Internal: Returns a Socket like object used internally to communicate with
+  # LDAP server.
   #
   # Typically a TCPSocket, but can be a OpenSSL::SSL::SSLSocket
   def socket

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -6,6 +6,14 @@ class Net::LDAP::Connection #:nodoc:
   LdapVersion = 3
   MaxSaslChallenges = 10
 
+  # Initialize a connection to an LDAP server
+  #
+  # :server
+  #   :hosts   Array of tuples specifying host, port
+  #   :host    host
+  #   :port    port
+  #   :socket  prepared socket
+  #
   def initialize(server = {})
     @server = server
     @instrumentation_service = server[:instrumentation_service]

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -606,6 +606,13 @@ class Net::LDAP::Connection #:nodoc:
     # First refactoring uses the existing methods open_connection and
     # prepare_socket to set @conn. Next cleanup would centralize connection
     # handling here.
-    open_connection(@server)
+    if @server[:socket]
+      prepare_socket(@server)
+    else
+      @server[:hosts] = [[@server[:host], @server[:port]]] if @server[:hosts].nil?
+      open_connection(@server)
+    end
+
+    @conn
   end
 end # class Connection

--- a/test/test_auth_adapter.rb
+++ b/test/test_auth_adapter.rb
@@ -1,9 +1,14 @@
 require 'test_helper'
 
 class TestAuthAdapter < Test::Unit::TestCase
+  class FakeSocket
+    def initialize(*args)
+    end
+  end
+
   def test_undefined_auth_adapter
-    flexmock(TCPSocket).should_receive(:new).ordered.with('ldap.example.com', 379).once.and_return(nil)
     conn = Net::LDAP::Connection.new(host: 'ldap.example.com', port: 379)
+    conn.socket_class = FakeSocket
     assert_raise Net::LDAP::AuthMethodUnsupportedError, "Unsupported auth method (foo)" do
       conn.bind(method: :foo)
     end

--- a/test/test_auth_adapter.rb
+++ b/test/test_auth_adapter.rb
@@ -7,8 +7,7 @@ class TestAuthAdapter < Test::Unit::TestCase
   end
 
   def test_undefined_auth_adapter
-    conn = Net::LDAP::Connection.new(host: 'ldap.example.com', port: 379)
-    conn.socket_class = FakeSocket
+    conn = Net::LDAP::Connection.new(host: 'ldap.example.com', port: 379, :socket_class => FakeSocket)
     assert_raise Net::LDAP::AuthMethodUnsupportedError, "Unsupported auth method (foo)" do
       conn.bind(method: :foo)
     end

--- a/test/test_ldap.rb
+++ b/test/test_ldap.rb
@@ -1,6 +1,28 @@
 require 'test_helper'
 
 class TestLDAPInstrumentation < Test::Unit::TestCase
+  # Fake Net::LDAP::Connection for testing
+  class FakeConnection
+    # It's difficult to instantiate Net::LDAP::PDU objects. Faking out what we
+    # need here until that object is brought under test and has it's constructor
+    # cleaned up.
+    class Result < Struct.new(:success?, :result_code); end
+
+    def initialize
+      @bind_success = Result.new(true, Net::LDAP::ResultCodeSuccess)
+      @search_success = Result.new(true, Net::LDAP::ResultCodeSizeLimitExceeded)
+    end
+
+    def bind(args = {})
+      @bind_success
+    end
+
+    def search(*args)
+      yield @search_success if block_given?
+      @search_success
+    end
+  end
+
   def setup
     @connection = flexmock(:connection, :close => true)
     flexmock(Net::LDAP::Connection).should_receive(:new).and_return(@connection)
@@ -15,8 +37,9 @@ class TestLDAPInstrumentation < Test::Unit::TestCase
   def test_instrument_bind
     events = @service.subscribe "bind.net_ldap"
 
-    bind_result = flexmock(:bind_result, :success? => true)
-    flexmock(@connection).should_receive(:bind).with(Hash).and_return(bind_result)
+    fake_connection = FakeConnection.new
+    @subject.connection = fake_connection
+    bind_result = fake_connection.bind
 
     assert @subject.bind
 
@@ -28,10 +51,9 @@ class TestLDAPInstrumentation < Test::Unit::TestCase
   def test_instrument_search
     events = @service.subscribe "search.net_ldap"
 
-    flexmock(@connection).should_receive(:bind).and_return(flexmock(:bind_result, :result_code => Net::LDAP::ResultCodeSuccess))
-    flexmock(@connection).should_receive(:search).with(Hash, Proc).
-                yields(entry = Net::LDAP::Entry.new("uid=user1,ou=users,dc=example,dc=com")).
-                and_return(flexmock(:search_result, :success? => true, :result_code => Net::LDAP::ResultCodeSuccess))
+    fake_connection = FakeConnection.new
+    @subject.connection = fake_connection
+    entry = fake_connection.search
 
     refute_nil @subject.search(:filter => "(uid=user1)")
 
@@ -44,10 +66,9 @@ class TestLDAPInstrumentation < Test::Unit::TestCase
   def test_instrument_search_with_size
     events = @service.subscribe "search.net_ldap"
 
-    flexmock(@connection).should_receive(:bind).and_return(flexmock(:bind_result, :result_code => Net::LDAP::ResultCodeSuccess))
-    flexmock(@connection).should_receive(:search).with(Hash, Proc).
-                yields(entry = Net::LDAP::Entry.new("uid=user1,ou=users,dc=example,dc=com")).
-                and_return(flexmock(:search_result, :success? => true, :result_code => Net::LDAP::ResultCodeSizeLimitExceeded))
+    fake_connection = FakeConnection.new
+    @subject.connection = fake_connection
+    entry = fake_connection.search
 
     refute_nil @subject.search(:filter => "(uid=user1)", :size => 1)
 

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -29,8 +29,7 @@ class TestLDAPConnection < Test::Unit::TestCase
       ["fail.SocketError", 636],
     ]
 
-    connection = Net::LDAP::Connection.new(:hosts => hosts)
-    connection.socket_class = FakeTCPSocket
+    connection = Net::LDAP::Connection.new(:hosts => hosts, :socket_class => FakeTCPSocket)
     connection.socket
   end
 
@@ -41,8 +40,7 @@ class TestLDAPConnection < Test::Unit::TestCase
       ["fail.SocketError", 636],
     ]
 
-    connection = Net::LDAP::Connection.new(:hosts => hosts)
-    connection.socket_class = FakeTCPSocket
+    connection = Net::LDAP::Connection.new(:hosts => hosts, :socket_class => FakeTCPSocket)
     connection.socket
   end
 
@@ -53,8 +51,7 @@ class TestLDAPConnection < Test::Unit::TestCase
       ["fail.SocketError", 636],
     ]
 
-    connection = Net::LDAP::Connection.new(:hosts => hosts)
-    connection.socket_class = FakeTCPSocket
+    connection = Net::LDAP::Connection.new(:hosts => hosts, :socket_class => FakeTCPSocket)
     assert_raise Net::LDAP::ConnectionError do
       connection.socket
     end
@@ -75,24 +72,21 @@ class TestLDAPConnection < Test::Unit::TestCase
   end
 
   def test_unresponsive_host
-    connection = Net::LDAP::Connection.new(:host => "fail.Errno::ETIMEDOUT", :port => 636)
-    connection.socket_class = FakeTCPSocket
+    connection = Net::LDAP::Connection.new(:host => "fail.Errno::ETIMEDOUT", :port => 636, :socket_class => FakeTCPSocket)
     assert_raise Net::LDAP::Error do
       connection.socket
     end
   end
 
   def test_blocked_port
-    connection = Net::LDAP::Connection.new(:host => "fail.SocketError", :port => 636)
-    connection.socket_class = FakeTCPSocket
+    connection = Net::LDAP::Connection.new(:host => "fail.SocketError", :port => 636, :socket_class => FakeTCPSocket)
     assert_raise Net::LDAP::Error do
       connection.socket
     end
   end
 
   def test_connection_refused
-    connection = Net::LDAP::Connection.new(:host => "fail.Errno::ECONNREFUSED", :port => 636)
-    connection.socket_class = FakeTCPSocket
+    connection = Net::LDAP::Connection.new(:host => "fail.Errno::ECONNREFUSED", :port => 636, :socket_class => FakeTCPSocket)
     stderr = capture_stderr do
       assert_raise Net::LDAP::ConnectionRefusedError do
         connection.socket
@@ -102,7 +96,7 @@ class TestLDAPConnection < Test::Unit::TestCase
   end
 
   def test_connection_timeout
-    connection = Net::LDAP::Connection.new(:host => "fail.Errno::ETIMEDOUT", :port => 636)
+    connection = Net::LDAP::Connection.new(:host => "fail.Errno::ETIMEDOUT", :port => 636, :socket_class => FakeTCPSocket)
     stderr = capture_stderr do
       assert_raise Net::LDAP::Error do
         connection.socket
@@ -111,8 +105,8 @@ class TestLDAPConnection < Test::Unit::TestCase
   end
 
   def test_raises_unknown_exceptions
-    connection = Net::LDAP::Connection.new(:host => "fail.StandardError", :port => 636)
-    assert_raise Net::LDAP::Error do
+    connection = Net::LDAP::Connection.new(:host => "fail.StandardError", :port => 636, :socket_class => FakeTCPSocket)
+    assert_raise StandardError do
       connection.socket
     end
   end


### PR DESCRIPTION
This PR's goal is to break the dependency between `Net::LDAP::Connection#initialize` and socket initialization. This would fix the [testing code smell](https://github.com/ruby-ldap/ruby-net-ldap/blob/c89d49377601b17225cc76da4431dd0cd3f294e3/test/test_auth_adapter.rb#L5) of stubbing out opening a TCPSocket whenever we initialize a connection object.

* add private #socket and use it for all socket communication
* remove socket initialization from constructor

I'm looking for early feedback as this is a work in progress because many existing tests expect the constructor to initialize the socket. I don't expect this to break the public API since `Net::LDAP::Connection` is an internal class.

cc @satoryu @javanthropus since I recall one of you asking for a better way to test this.