### PR TITLE
Net::LDAP#encryption accepts string

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -590,6 +590,7 @@ class Net::LDAP
   # This method is deprecated. 
   #
   def encryption(args)
+    warn "Deprecation warning: please give :encryption option as a Hash to Net::LDAP.new"
     return if args.nil?
     return @encryption = args if args.is_a? Hash
 

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -590,6 +590,7 @@ class Net::LDAP
   #   }
   def encryption(args)
     return if args.nil?
+    return @encryption = args if args.is_a? Hash
 
     case method = args.to_sym
     when :simple_tls, :start_tls

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -589,9 +589,11 @@ class Net::LDAP
   #     :tls_options => { :ca_file => "/etc/cafile.pem", :ssl_version => "TLSv1_1" }
   #   }
   def encryption(args)
-    case args
+    return if args.nil?
+
+    case method = args.to_sym
     when :simple_tls, :start_tls
-      args = { :method => args, :tls_options => {} }
+      args = { :method => method, :tls_options => {} }
     end
     @encryption = args
   end

--- a/test/test_ldap.rb
+++ b/test/test_ldap.rb
@@ -64,4 +64,10 @@ class TestLDAPInstrumentation < Test::Unit::TestCase
     @subject.auth "joe_user", password
     assert_not_include(@subject.inspect, password)
   end
+
+  def test_encryption
+    enc = @subject.encryption('start_tls')
+
+    assert_equal enc[:method], :start_tls
+  end
 end


### PR DESCRIPTION
As #238 reported, if `Net::LDAP.new` is given encryption type as `String` instead of `Symbol`, it breaks in establishing a connection. 

This pull request provides a solution: allowing to give encryption type as `String`. 

CC: @darix