### PR TITLE
Drop support for ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   # optional
+  - 2.3.0-preview1
   - ruby-head
   - jruby-19mode
   - jruby-head
@@ -21,6 +21,7 @@ script: bundle exec rake ci
 
 matrix:
   allow_failures:
+    - rvm: 2.3.0-preview1
     - rvm: ruby-head
     - rvm: jruby-19mode
     - rvm: jruby-head

--- a/net-ldap.gemspec
+++ b/net-ldap.gemspec
@@ -26,7 +26,7 @@ the most recent LDAP RFCs (4510-4519, plutions of 4520-4532).}
   s.homepage = %q{http://github.com/ruby-ldap/ruby-net-ldap}
   s.rdoc_options = ["--main", "README.rdoc"]
   s.require_paths = ["lib"]
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.0.0"
   s.summary = %q{Net::LDAP for Ruby (also called net-ldap) implements client access for the Lightweight Directory Access Protocol (LDAP), an IETF standard protocol for accessing distributed directory services}
 
   s.add_development_dependency("flexmock", "~> 1.3")


### PR DESCRIPTION
As we discussed in #235, now is time to say bye to ruby 1.9.3. 

haha, net-ldap is already ready for support 2.3.0 :tada: 