### PR TITLE
Adds correct UTF-8 encoding to Net::BER::BerIdentifiedString

### DIFF
--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -293,13 +293,43 @@ end
 
 ##
 # A String object with a BER identifier attached.
+# 
 class Net::BER::BerIdentifiedString < String
   attr_accessor :ber_identifier
+
+  # The binary data provided when parsing the result of the LDAP search
+  # has the encoding 'ASCII-8BIT' (which is basically 'BINARY', or 'unknown').
+  # 
+  # This is the kind of a backtrace showing how the binary `data` comes to
+  # BerIdentifiedString.new(data):
+  #
+  #  @conn.read_ber(syntax)
+  #     -> StringIO.new(self).read_ber(syntax), i.e. included from module
+  #     -> Net::BER::BERParser.read_ber(syntax) 
+  #        -> (private)Net::BER::BERParser.parse_ber_object(syntax, id, data)
+  # 
+  # In the `#parse_ber_object` method `data`, according to its OID, is being
+  # 'casted' to one of the Net::BER:BerIdentifiedXXX classes.
+  # 
+  # As we are using LDAP v3 we can safely assume that the data is encoded
+  # in UTF-8 and therefore the only thing to be done when instantiating is to
+  # switch the encoding from 'ASCII-8BIT' to 'UTF-8'.
+  #
+  # Unfortunately, there are some ActiveDirectory specific attributes
+  # (like `objectguid`) that should remain binary (do they really?).
+  # Using the `#valid_encoding?` we can trap this cases. Special cases like
+  # Japanese, Korean, etc. encodings might also profit from this. However
+  # I have no clue how this encodings function.
   def initialize args
-    super begin
-      args.respond_to?(:encode) ? args.encode('UTF-8') : args
-    rescue
-      args
+    super
+    # 
+    # Check the encoding of the newly created String and set the encoding
+    # to 'UTF-8' (NOTE: we do NOT change the bytes, but only set the 
+    # encoding to 'UTF-8').
+    current_encoding = encoding
+    if current_encoding == Encoding::BINARY
+      force_encoding('UTF-8')
+      force_encoding(current_encoding) unless valid_encoding?
     end
   end
 end

--- a/test/ber/test_ber.rb
+++ b/test/ber/test_ber.rb
@@ -130,12 +130,20 @@ class TestBERIdentifiedString < Test::Unit::TestCase
   def test_ascii_data_in_utf8
     data = "some text".force_encoding("UTF-8")
     bis = Net::BER::BerIdentifiedString.new(data)
+    
+    assert bis.valid_encoding?, "should be a valid encoding"
+    assert_equal "UTF-8", bis.encoding.name
+  end
+  
+  def test_umlaut_data_in_utf8
+    data = "Müller".force_encoding("UTF-8")
+    bis = Net::BER::BerIdentifiedString.new(data)
 
     assert bis.valid_encoding?, "should be a valid encoding"
     assert_equal "UTF-8", bis.encoding.name
   end
 
-  def test_ut8_data_in_utf8
+  def test_utf8_data_in_utf8
     data = ["e4b8ad"].pack("H*").force_encoding("UTF-8")
     bis = Net::BER::BerIdentifiedString.new(data)
 


### PR DESCRIPTION
Dear Net-LDAP maintainers

Currently, net-ldap returns values containing umlauts (e.g. 'Müller') with an encoding as 'ASCII-8BIT'.
This is wrong. LDAP in version 3 should encode all data in 'UTF-8' and therefore when
casting returned ''string'' data into a `Net::BER::BerIdentifiedString` the encoding should be 'UTF-8'.

The current code tries to '#encode('UTF-8')' which results in an
`Encoding::UndefinedConversionError: "\xC3" from ASCII-8BIT to UTF-8`. This error is trapped
and the binary string is returned instead.

If we assume that the data coming from our LDAP/AD-Server is correctly encoded in 'UTF-8', there is
no need to use `#encode`. The only thing is to set correctly the encoding of the (string) data, i.e. to use `force_encoding`.

Example:

```ruby
bin_str = "Müller".b
p [:bin_str, bin_str.encoding, bin_str.bytes, bin_str]
# => [:bin_str, #<Encoding:ASCII-8BIT>, [77, 195, 188, 108, 108, 101, 114], "M\xC3\xBCller"]

# Now try to 'encode' it:
bin_str.encode('UTF-8')
# =>Encoding::UndefinedConversionError: "\xC3" from ASCII-8BIT to UTF-8
    
# Better:
bin_str.force_encoding('UTF-8')
p [:bin_str, bin_str.encoding, bin_str.bytes, bin_str]
# => [:bin_str, #<Encoding:UTF-8>, [77, 195, 188, 108, 108, 101, 114], "Müller"]
```
I must admit that I have only checked the code (and added one test case) for Umlauts (and characters more or less covered by ISO-8859-1). I have no idea how to test against 
Korean, Japanese, Russian, or Chinese encodings.

Nevertheless, I am pretty sure that the current code is bogus for any 'non-ASCII' characters.

Please let me know, if you need further details and I'd be happy to help you out.

regards
andi 