### PR TITLE
Set a connect_timeout for the creation of a socket

### DIFF
--- a/lib/net/ber.rb
+++ b/lib/net/ber.rb
@@ -293,24 +293,24 @@ end
 
 ##
 # A String object with a BER identifier attached.
-# 
+#
 class Net::BER::BerIdentifiedString < String
   attr_accessor :ber_identifier
 
   # The binary data provided when parsing the result of the LDAP search
   # has the encoding 'ASCII-8BIT' (which is basically 'BINARY', or 'unknown').
-  # 
+  #
   # This is the kind of a backtrace showing how the binary `data` comes to
   # BerIdentifiedString.new(data):
   #
   #  @conn.read_ber(syntax)
   #     -> StringIO.new(self).read_ber(syntax), i.e. included from module
-  #     -> Net::BER::BERParser.read_ber(syntax) 
+  #     -> Net::BER::BERParser.read_ber(syntax)
   #        -> (private)Net::BER::BERParser.parse_ber_object(syntax, id, data)
-  # 
+  #
   # In the `#parse_ber_object` method `data`, according to its OID, is being
   # 'casted' to one of the Net::BER:BerIdentifiedXXX classes.
-  # 
+  #
   # As we are using LDAP v3 we can safely assume that the data is encoded
   # in UTF-8 and therefore the only thing to be done when instantiating is to
   # switch the encoding from 'ASCII-8BIT' to 'UTF-8'.
@@ -322,9 +322,9 @@ class Net::BER::BerIdentifiedString < String
   # I have no clue how this encodings function.
   def initialize args
     super
-    # 
+    #
     # Check the encoding of the newly created String and set the encoding
-    # to 'UTF-8' (NOTE: we do NOT change the bytes, but only set the 
+    # to 'UTF-8' (NOTE: we do NOT change the bytes, but only set the
     # encoding to 'UTF-8').
     current_encoding = encoding
     if current_encoding == Encoding::BINARY

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -3,6 +3,9 @@
 class Net::LDAP::Connection #:nodoc:
   include Net::LDAP::Instrumentation
 
+  # Seconds before failing for socket connect timeout
+  DefaultConnectTimeout = 5
+
   LdapVersion = 3
   MaxSaslChallenges = 10
 
@@ -31,10 +34,14 @@ class Net::LDAP::Connection #:nodoc:
     hosts = server[:hosts]
     encryption = server[:encryption]
 
+    socket_opts = {
+      connect_timeout: server[:connect_timeout] || DefaultConnectTimeout
+    }
+
     errors = []
     hosts.each do |host, port|
       begin
-        prepare_socket(server.merge(socket: TCPSocket.new(host, port)))
+        prepare_socket(server.merge(socket: Socket.tcp(host, port, socket_opts)))
         return
       rescue Net::LDAP::Error, SocketError, SystemCallError,
              OpenSSL::SSL::SSLError => e

--- a/script/install-openldap
+++ b/script/install-openldap
@@ -109,4 +109,7 @@ chgrp ssl-cert /etc/ssl/private/ldap01_slapd_key.pem
 chmod g+r /etc/ssl/private/ldap01_slapd_key.pem
 chmod o-r /etc/ssl/private/ldap01_slapd_key.pem
 
+# Drop packets on a secondary port used to specific timeout tests
+iptables -A OUTPUT -p tcp -j DROP --dport 8389
+
 service slapd restart

--- a/test/ber/test_ber.rb
+++ b/test/ber/test_ber.rb
@@ -130,11 +130,11 @@ class TestBERIdentifiedString < Test::Unit::TestCase
   def test_ascii_data_in_utf8
     data = "some text".force_encoding("UTF-8")
     bis = Net::BER::BerIdentifiedString.new(data)
-    
+
     assert bis.valid_encoding?, "should be a valid encoding"
     assert_equal "UTF-8", bis.encoding.name
   end
-  
+
   def test_umlaut_data_in_utf8
     data = "Müller".force_encoding("UTF-8")
     bis = Net::BER::BerIdentifiedString.new(data)

--- a/test/integration/test_bind.rb
+++ b/test/integration/test_bind.rb
@@ -5,6 +5,14 @@ class TestBindIntegration < LDAPIntegrationTestCase
     assert @ldap.bind(method: :simple, username: "uid=user1,ou=People,dc=rubyldap,dc=com", password: "passworD1"), @ldap.get_operation_result.inspect
   end
 
+  def test_bind_timeout
+    @ldap.port = 8389
+    error = assert_raise Net::LDAP::Error do
+      @ldap.bind(method: :simple, username: "uid=user1,ou=People,dc=rubyldap,dc=com", password: "passworD1")
+    end
+    assert_equal('Connection timed out - user specified timeout', error.message)
+  end
+
   def test_bind_anonymous_fail
     refute @ldap.bind(method: :simple, username: "uid=user1,ou=People,dc=rubyldap,dc=com", password: ""), @ldap.get_operation_result.inspect
 

--- a/test/test_auth_adapter.rb
+++ b/test/test_auth_adapter.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class TestAuthAdapter < Test::Unit::TestCase
   def test_undefined_auth_adapter
-    flexmock(TCPSocket).should_receive(:new).ordered.with('ldap.example.com', 379).once.and_return(nil)
+    flexmock(Socket).should_receive(:tcp).ordered.with('ldap.example.com', 379, { connect_timeout: 5 }).once.and_return(nil)
+
     conn = Net::LDAP::Connection.new(host: 'ldap.example.com', port: 379)
     assert_raise Net::LDAP::AuthMethodUnsupportedError, "Unsupported auth method (foo)" do
       conn.bind(method: :foo)


### PR DESCRIPTION
Currently when an LDAP server is not reachable (for instance, packets are dropped), users of this library end up waiting for a quite long period of time. This is very rarely acceptable and can easily lead to a chain of failures with several services timing out before the socket creation actually fails.
 
This patch uses Socket.tcp instead of TCPSocket.new and provides a default connect_timeout of 1 second.

_Notes:_
- I couldn't find a way in the integration tests to write a proper test for this. As far as I can tell, there are no tests at that level to validate connection failures, etc... Am I right?
- I set the timeout to 1 sec, but probably a better way could be setting it to a higher value and provide an easier way to customise it?
