### PR TITLE
Raises errors when giving encryption as non-Hash object

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -540,6 +540,9 @@ class Net::LDAP
     @base = args[:base] || DefaultTreebase
     @force_no_page = args[:force_no_page] || DefaultForceNoPage
     @encryption = args[:encryption] # may be nil
+    if !@encryption.nil? and !@encryption.is_a?(Hash)
+      raise ArgumentError, "encryption must be given as Hash"
+    end
     @connect_timeout = args[:connect_timeout]
 
     if pr = @auth[:password] and pr.respond_to?(:call)

--- a/test/test_ldap.rb
+++ b/test/test_ldap.rb
@@ -91,4 +91,10 @@ class TestLDAPInstrumentation < Test::Unit::TestCase
 
     assert_equal enc[:method], :start_tls
   end
+
+  def test_initialize
+    assert_raise ArgumentError, "encryption must be given as Hash" do
+      Net::LDAP.new encryption: [ :simple_tls ]
+    end
+  end
 end


### PR DESCRIPTION
In #250 , `Net::LDAP` of the latest version 0.13.0 accepts encryption options on its initializer. It causes an error when creating a connection as reported. 

This PR provides a validation which check whether a given `encryption` option is a Hash or not. 