### PR TITLE
Addresses the LDAPS vulnerability to MITM attacks by properly authenticating the hostname

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -51,8 +51,12 @@ class Net::LDAP::Connection #:nodoc:
     hosts.each do |host, port|
       begin
         prepare_socket(server.merge(socket: @socket_class.new(host, port, socket_opts)))
-        if encryption && ! encryption[:tls_options] && encryption[:tls_options][:verify_mode]
-          if encryption[:tls_options][:verify_mode] != OpenSSL::SSL::VERIFY_NONE
+        if encryption
+          if encryption[:tls_options] &&
+             encryption[:tls_options][:verify_mode] &&
+             encryption[:tls_options][:verify_mode] == OpenSSL::SSL::VERIFY_NONE
+            warn "not verifying SSL hostname of LDAPS server"
+          else
             @conn.post_connection_check(host)
           end
         end

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -51,8 +51,10 @@ class Net::LDAP::Connection #:nodoc:
     hosts.each do |host, port|
       begin
         prepare_socket(server.merge(socket: @socket_class.new(host, port, socket_opts)))
-        if encryption[:tls_options][:verify_mode] != OpenSSL::SSL::VERIFY_NONE
+        if encryption && ! encryption[:tls_options] && encryption[:tls_options][:verify_mode]
+          if encryption[:tls_options][:verify_mode] != OpenSSL::SSL::VERIFY_NONE
             @conn.post_connection_check(host)
+          end
         end
         return
       rescue Net::LDAP::Error, SocketError, SystemCallError,

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -51,6 +51,9 @@ class Net::LDAP::Connection #:nodoc:
     hosts.each do |host, port|
       begin
         prepare_socket(server.merge(socket: @socket_class.new(host, port, socket_opts)))
+        if encryption[:tls_options][:verify_mode] != OpenSSL::SSL::VERIFY_NONE
+            @conn.post_connection_check(host)
+        end
         return
       rescue Net::LDAP::Error, SocketError, SystemCallError,
              OpenSSL::SSL::SSLError => e


### PR DESCRIPTION
This attempts to address [LDAPS vulnerable to MITM - failure to validate hostname against CN or SAN in X509 Cert](https://github.com/ruby-ldap/ruby-net-ldap/issues/258).

It has been briefly tested and when connecting or binding via LDAP against a <missmatched hostname>, the following exception occurs
```
Net::LDAP::Error: hostname "<missmatched hostname>" does not match the server certificate
```

Users who want TLS/SSL just for encryption and don't care about hostname validation should be able to use  `:tls_options => { :verify_mode => OpenSSL::SSL::VERIFY_NONE }` to allow for insecure connections.