### PR TITLE
Update Docs: Net::LDAP now requires ruby >= 2

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -25,7 +25,7 @@ See Net::LDAP for documentation and usage samples.
 
 == Requirements
 
-Net::LDAP requires a Ruby 1.9.3 compatible interpreter or better.
+Net::LDAP requires a Ruby 2.0.0 compatible interpreter or better.
 
 == Install
 


### PR DESCRIPTION
Ran into this while installing the gem on JRuby 1.7.24