### PR TITLE
Normalize the encryption parameter passed to the LDAP constructor

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -539,7 +539,7 @@ class Net::LDAP
     @auth = args[:auth] || DefaultAuth
     @base = args[:base] || DefaultTreebase
     @force_no_page = args[:force_no_page] || DefaultForceNoPage
-    @encryption = args[:encryption] # may be nil
+    @encryption = normalize_encryption(args[:encryption]) # may be nil
     @connect_timeout = args[:connect_timeout]
 
     if pr = @auth[:password] and pr.respond_to?(:call)
@@ -609,13 +609,7 @@ class Net::LDAP
   def encryption(args)
     warn "Deprecation warning: please give :encryption option as a Hash to Net::LDAP.new"
     return if args.nil?
-    return @encryption = args if args.is_a? Hash
-
-    case method = args.to_sym
-    when :simple_tls, :start_tls
-      args = { :method => method, :tls_options => {} }
-    end
-    @encryption = args
+    @encryption = normalize_encryption(args)
   end
 
   # #open takes the same parameters as #new. #open makes a network
@@ -1323,4 +1317,17 @@ class Net::LDAP
     }
     raise e
   end
+
+  # Normalize encryption parameter the constructor accepts, expands a few
+  # convenience symbols into recognizable hashes
+  def normalize_encryption(args)
+    return if args.nil?
+    return args if args.is_a? Hash
+
+    case method = args.to_sym
+    when :simple_tls, :start_tls
+      { :method => method, :tls_options => {} }
+    end
+  end
+
 end # class LDAP

--- a/test/test_ldap.rb
+++ b/test/test_ldap.rb
@@ -91,4 +91,24 @@ class TestLDAPInstrumentation < Test::Unit::TestCase
 
     assert_equal enc[:method], :start_tls
   end
+
+  def test_normalize_encryption_symbol
+    enc = @subject.send(:normalize_encryption, :start_tls)
+    assert_equal enc, {:method => :start_tls, :tls_options => {}}
+  end
+
+  def test_normalize_encryption_nil
+    enc = @subject.send(:normalize_encryption, nil)
+    assert_equal enc, nil
+  end
+
+  def test_normalize_encryption_string
+    enc = @subject.send(:normalize_encryption, 'start_tls')
+    assert_equal enc, {:method => :start_tls, :tls_options => {}}
+  end
+
+  def test_normalize_encryption_hash
+    enc = @subject.send(:normalize_encryption, {:method => :start_tls, :tls_options => {:foo => :bar}})
+    assert_equal enc, {:method => :start_tls, :tls_options => {:foo => :bar}}
+  end
 end


### PR DESCRIPTION
This PR restores API functionality that was broken on 0.13, the encryption parameter can again be specified as a symbol and will be normalized to the expected hash.

This is in reference to ruby-ldap/ruby-net-ldap#250