### PR TITLE
Send DN and newPassword with password_modify request

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -593,11 +593,11 @@ class Net::LDAP::Connection #:nodoc:
 
     ext_seq = [Net::LDAP::PasswdModifyOid.to_ber_contextspecific(0)]
 
-    unless args[:old_password].nil?
-      pwd_seq = [args[:old_password].to_ber(0x81)]
-      pwd_seq << args[:new_password].to_ber(0x82) unless args[:new_password].nil?
-      ext_seq << pwd_seq.to_ber_sequence.to_ber(0x81)
-    end
+    pwd_seq = []
+    pwd_seq << dn.to_ber(0x80)
+    pwd_seq << args[:old_password].to_ber(0x81) unless args[:old_password].nil?
+    pwd_seq << args[:new_password].to_ber(0x82) unless args[:new_password].nil?
+    ext_seq << pwd_seq.to_ber_sequence.to_ber(0x81)
 
     request = ext_seq.to_ber_appsequence(Net::LDAP::PDU::ExtendedRequest)
 

--- a/test/integration/test_password_modify.rb
+++ b/test/integration/test_password_modify.rb
@@ -3,7 +3,8 @@ require_relative '../test_helper'
 class TestPasswordModifyIntegration < LDAPIntegrationTestCase
   def setup
     super
-    @ldap.authenticate 'cn=admin,dc=rubyldap,dc=com', 'passworD1'
+    @admin_account = {dn: 'cn=admin,dc=rubyldap,dc=com', password: 'passworD1', method: :simple}
+    @ldap.authenticate @admin_account[:dn], @admin_account[:password]
 
     @dn = 'uid=modify-password-user1,ou=People,dc=rubyldap,dc=com'
 
@@ -71,6 +72,18 @@ class TestPasswordModifyIntegration < LDAPIntegrationTestCase
       'Old password should no longer be valid'
 
     assert @ldap.bind(username: @dn, password: generated_password, method: :simple),
+      'New password should be valid'
+  end
+
+  def test_password_modify_overwrite_old_password
+    assert @ldap.password_modify(dn: @dn,
+                                 auth: @admin_account,
+                                 new_password: 'passworD3')
+
+    refute @ldap.bind(username: @dn, password: 'passworD1', method: :simple),
+      'Old password should no longer be valid'
+
+    assert @ldap.bind(username: @dn, password: 'passworD3', method: :simple),
       'New password should be valid'
   end
 


### PR DESCRIPTION
This change allows an admin to overwrite the password of a user a) without specifying the old one and b) setting the new one.
