### PR TITLE
Fix misplaced constant

### DIFF
--- a/lib/net/ldap/auth_adapter/sasl.rb
+++ b/lib/net/ldap/auth_adapter/sasl.rb
@@ -4,6 +4,8 @@ module Net
   class LDAP
     class AuthAdapter
       class Sasl < Net::LDAP::AuthAdapter
+        MaxSaslChallenges = 10
+
         #--
         # Required parameters: :mechanism, :initial_credential and
         # :challenge_response

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -7,7 +7,6 @@ class Net::LDAP::Connection #:nodoc:
   DefaultConnectTimeout = 5
 
   LdapVersion = 3
-  MaxSaslChallenges = 10
 
   # Initialize a connection to an LDAP server
   #


### PR DESCRIPTION
The constant `MaxSaslChallenges` was apparently left behind when authentication methods were refactored.