### PR TITLE
[WIP] add URL support to constructor, some smarter TLS defaults

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -82,6 +82,8 @@ Metrics/BlockNesting:
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 431
+  Exclude:
+    - 'lib/net/ldap.rb'
 
 # Offense count: 22
 Metrics/CyclomaticComplexity:

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -566,10 +566,6 @@ class Net::LDAP
 
     if pr = @auth[:password] and pr.respond_to?(:call)
       @auth[:password] = pr.call
-    elsif @uri.user || @uri.password
-      @auth[:method] = :simple
-      @auth[:username] ||= @uri.user if @uri.user
-      @auth[:password] ||= @uri.password if @uri.password
     end
 
     @instrumentation_service = args[:instrumentation_service]

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -551,7 +551,11 @@ class Net::LDAP
     @hosts = args[:hosts]
     @verbose = false # Make this configurable with a switch on the class.
     @auth = args[:auth] || DefaultAuth
-    @base = args[:base] || DefaultTreebase
+    @base = args[:base] || if @uri.path && @uri.path.length > 1
+                             URI.decode(@uri.path[1..-1])
+                           else
+                             DefaultTreebase
+                           end
     @force_no_page = args[:force_no_page] || DefaultForceNoPage
     @encryption = normalize_encryption(args[:encryption]) # may be nil
     if @uri.scheme == 'ldaps'

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -507,13 +507,13 @@ class Net::LDAP
   #   talking over the public internet), you need to set :tls_options
   #   something like this...
   #
-  #   Net::LDAP.new(
-  #     # ... set host, bind dn, etc ...
-  #     encryption: {
-  #       method: :simple_tls,
-  #       tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS,
-  #     }
-  #   )
+  #     Net::LDAP.new(
+  #       # ... set host, bind dn, etc ...
+  #       encryption: {
+  #         method: :simple_tls,
+  #         tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS,
+  #       }
+  #     )
   #
   #   The above will use the operating system-provided store of CA
   #   certificates to validate your LDAP server's cert.
@@ -528,17 +528,16 @@ class Net::LDAP
   #   `update-ca-certificates`), then the cert should pass validation.
   #   To ignore the OS's CA store, put your CA in a PEM-encoded file and...
   #
-  #   encryption: {
-  #     method:      :simple_tls,
-  #     tls_options: { ca_file:     '/path/to/my-little-ca.pem',
-  #                    ssl_version: 'TLSv1_1' },
-  #   }
+  #     encryption: {
+  #       method:      :simple_tls,
+  #       tls_options: { ca_file:     '/path/to/my-little-ca.pem',
+  #                      ssl_version: 'TLSv1_1' },
+  #     }
   #
   #   As you might guess, the above example also fails the connection
   #   if the client can't negotiate TLS v1.1.
-  #   tls_options is ultimately passed to OpenSSL::SSL::SSLContext#set_params
-  #   For more details, see
-  #    http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html
+  #   tls_options is ultimately passed to
+  #   +OpenSSL::SSL::SSLContext#set_params+, For more details, see http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html
   #
   # Instantiating a Net::LDAP object does <i>not</i> result in network
   # traffic to the LDAP server. It simply stores the connection and binding

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -547,19 +547,19 @@ class Net::LDAP
   def initialize(args = {})
     # URI.parse('') returns a valid URI object, but with all its
     # attributes set to nil. This is convenient for chained '||'
-    @uri = URI.parse(args[:uri] || '')
+    @url = URI.parse(args[:uri] || '')
 
-    unless [nil, 'ldaps', 'ldap'].include? @uri.scheme
+    unless [nil, 'ldaps', 'ldap'].include? @url.scheme
       raise ProtocolNotSupported,
-            "scheme '#{@uri.scheme}' unsupported, use 'ldap' or 'ldaps'"
+            "scheme '#{@url.scheme}' unsupported, use 'ldap' or 'ldaps'"
     end
-    @host = args[:host] || @uri.host || DefaultHost
-    @port = args[:port] || @uri.port || DefaultPort
+    @host = args[:host] || @url.host || DefaultHost
+    @port = args[:port] || @url.port || DefaultPort
     @hosts = args[:hosts]
     @verbose = false # Make this configurable with a switch on the class.
     @auth = args[:auth] || DefaultAuth
-    @base = args[:base] || if @uri.path && @uri.path.length > 1
-                             URI.decode(@uri.path[1..-1])
+    @base = args[:base] || if @url.path && @url.path.length > 1
+                             URI.decode(@url.path[1..-1])
                            else
                              DefaultTreebase
                            end
@@ -1348,7 +1348,7 @@ class Net::LDAP
       "encryption may be hash, nil, or one of [:simple_tls, :start_tls, true]"
 
     if args.nil?
-      return nil unless @uri.scheme == 'ldaps'
+      return nil unless @url.scheme == 'ldaps'
       { method:      :simple_tls,
         tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS }
     elsif args.is_a? Hash
@@ -1359,7 +1359,7 @@ class Net::LDAP
         { method:      method,
           tls_options: {} }
       when :true
-        scheme = if @uri.scheme == 'ldaps' || @port == DefaultTlsPort
+        scheme = if @url.scheme == 'ldaps' || @port == DefaultTlsPort
                    :simple_tls
                  else
                    :start_tls

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1352,7 +1352,11 @@ class Net::LDAP
       { method:      :simple_tls,
         tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS }
     elsif args.is_a? Hash
-      args
+      if args[:tls_options].to_sym == :default
+        args.merge(tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS)
+      else
+        args
+      end
     else
       case method = args.to_s.to_sym
       when :simple_tls, :start_tls

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -549,7 +549,7 @@ class Net::LDAP
     # attributes set to nil. This is convenient for chained '||'
     @uri = URI.parse(args[:uri] || '')
 
-    unless ['ldaps', 'ldap'].include? @uri.scheme
+    unless [nil, 'ldaps', 'ldap'].include? @uri.scheme
       raise ProtocolNotSupported,
             "scheme '#{@uri.scheme}' unsupported, use 'ldap' or 'ldaps'"
     end

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -545,7 +545,7 @@ class Net::LDAP
   # cert validation errors itself; #bind does instead.
   def initialize(args = {})
     # URI.parse('') returns a valid URI object, but with all its
-    # attributes set to nil. This is convenient for chainging the '||'
+    # attributes set to nil. This is convenient for chained '||'
     @uri = URI.parse(args[:uri] || '')
 
     unless ['ldaps', 'ldap'].include? @uri.scheme

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -546,6 +546,10 @@ class Net::LDAP
   def initialize(args = {})
     @uri = URI.parse(args[:uri] || '')
 
+    unless ['ldaps', 'ldap'].include? @uri.scheme
+      raise ProtocolNotSupported,
+            "scheme '#{@uri.scheme}' unsupported, use 'ldap' or 'ldaps'"
+    end
     @host = args[:host] || @uri.host || DefaultHost
     @port = args[:port] || @uri.port || DefaultPort
     @hosts = args[:hosts]

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -544,6 +544,8 @@ class Net::LDAP
   # parameters in the object. That's why Net::LDAP.new doesn't throw
   # cert validation errors itself; #bind does instead.
   def initialize(args = {})
+    # URI.parse('') returns a valid URI object, but with all its
+    # attributes set to nil. This is convenient for chainging the '||'
     @uri = URI.parse(args[:uri] || '')
 
     unless ['ldaps', 'ldap'].include? @uri.scheme

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -70,4 +70,5 @@ class Net::LDAP
   class FilterTypeUnknownError < Error; end
   class FilterSyntaxInvalidError < Error; end
   class EntryOverflowError < Error; end
+  class ProtocolNotSupported < Error; end
 end


### PR DESCRIPTION
fixes #246 (hi @danleyden), relevant RFCs are [2255 (obsolete)](https://tools.ietf.org/html/rfc2255) and [4516](https://tools.ietf.org/html/rfc4516). This is in-progress because I haven't updated the class docs or tests yet. Before I do, I wanted to open the PR and make sure I'm generally on the right track. Example:
```
Net::LDAP.new(url: 'ldaps://ldap01.example.com:9636/dc=example,dc=com',
              auth: {method: :simple, username: <bind_dn>, password: <bind_pw>})
#
# is the same as
#
Net::LDAP.new(host: 'ldap01.example.com',
              port: 9636,
              base: 'dc=example,dc=com',
              encryption: {method: :simple_tls,
                           tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS },
              auth: {method: :simple, username: <bind_dn>, password: <bind_pw>})
```
but wait, there's more!
```
Net::LDAP.new(url: 'ldap://ldap01.example.com',
              encryption: true)
#
# is the same as
#
Net::LDAP.new(host: 'ldap01.example.com',
              encryption: {method: :start_tls,
                           tls_options: :default })
#
# or if you're not into the whole brevity thing
#
Net::LDAP.new(host: 'ldap01.example.com',
              encryption: {method: :start_tls
                           tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS })
```

## TLS changes
* If you set `encryption: true` (previously a noop), the internal `@encryption` hash gets populated with the OpenSSL defaults. Those defaults set `VERIFY_PEER` (cert validation!) *and* use the default OS-provided CA certificate store. Yay easy cert validation!
* To be explicit: the new `encryption: true` argument does **NOT** require the use of `url`. If you don't set an `url`, `method: :start_tls` vs `:simple_tls` is set by looking at the port. 636 is `:simple_tls`, everything else is `:start_tls`.
* `tls_options: :default` is a shortcut for `tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS`. That string is too long.

## More rambling
Aside from search base DN, the LDAP URL RFCs also allow you to specify a constrained list of attributes to return on search results, a scope (sub/one/all), and a search filter.  A default scope for searches seems like a reasonable thing for `Net::LDAP` instances to track, similar to base DN, but it doesn't currently so I didn't add it. I could see an argument for writing a `Net::LDAP#search_by_url`, or extending the existing `Net::LDAP#search`, but I think this gem has higher priorities.

Credentials: The RFCs don't say anything about accepting username/pw befor the hostname (e.g. `http://user:password@www.example.com/`), and it's in formal ABFN and everything, so I've avoided handling those. I don't particularly want to encourage people to put passwords in URLs.

You'll note from the rubocop config change that rubocop started complaining about `Net::LDAP`'s length. I think we can shrink that considerably by moving a ton of constants into their own class/module. That's getting to be a more major change, though, so next time.

/cc @jch 