### PR TITLE
Fixed Exception: incompatible character encodings: ASCII-8BIT and UTF-8 in filter.rb

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -645,8 +645,15 @@ class Net::LDAP::Filter
 
   ##
   # Converts escaped characters (e.g., "\\28") to unescaped characters
+  # @note slawson20170317: Don't attempt to unescape 16 byte binary data which we assume are objectGUIDs
+  # The binary form of 5936AE79-664F-44EA-BCCB-5C39399514C6 triggers a BINARY -> UTF-8 conversion error        
   def unescape(right)
-    right.to_s.gsub(/\\([a-fA-F\d]{2})/) { [$1.hex].pack("U") }
+    right = right.to_s
+    if right.length == 16 && right.encoding == Encoding::BINARY
+      right
+    else
+      right.to_s.gsub(/\\([a-fA-F\d]{2})/) { [$1.hex].pack("U") }
+    end
   end
   private :unescape
 


### PR DESCRIPTION
Fixed Exception: incompatible character encodings: ASCII-8BIT and UTF-8

The binary form of 5936AE79-664F-44EA-BCCB-5C39399514C6 triggers a BINARY -> UTF-8 conversion error