### PR TITLE
Added method to get a duplicate of the internal Hash

### DIFF
--- a/lib/net/ldap/entry.rb
+++ b/lib/net/ldap/entry.rb
@@ -134,6 +134,13 @@ class Net::LDAP::Entry
   end
 
   ##
+  # Creates a duplicate of the internal Hash containing the attributes
+  # of the entry.
+  def to_h
+    @myhash.dup
+  end
+
+  ##
   # Accesses each of the attributes present in the Entry.
   #
   # Calls a user-supplied block with each attribute in turn, passing two

--- a/test/test_entry.rb
+++ b/test/test_entry.rb
@@ -39,6 +39,21 @@ class TestEntry < Test::Unit::TestCase
     assert_equal ['Jensen'], @entry['Sn']
     assert_equal ['Jensen'], @entry['SN']
   end
+
+  def test_to_h
+    @entry['sn'] = 'Jensen'
+    expected     = {
+      dn: ['cn=Barbara,o=corp'],
+      sn: ['Jensen'],
+    }
+    duplicate = @entry.to_h
+    assert_equal expected, duplicate
+
+    # check that changing the duplicate
+    # does not affect the internal state
+    duplicate.delete(:sn)
+    assert_not_equal duplicate, @entry.to_h
+  end
 end
 
 class TestEntryLDIF < Test::Unit::TestCase


### PR DESCRIPTION
This aims to avoid constructs like this:

```ruby
attributes = {}
ldap.search_root_dse.each { |key, value|
  attributes[key] = value
}
attributes
```

Which now will look like:
```ruby
ldap.search_root_dse.to_h
```