### PR TITLE
Explicitly define behavior of empty `tls_options`

### DIFF
--- a/test/integration/test_bind.rb
+++ b/test/integration/test_bind.rb
@@ -122,6 +122,25 @@ class TestBindIntegration < LDAPIntegrationTestCase
            @ldap.get_operation_result.inspect
   end
 
+  def test_bind_tls_with_valid_hostname_no_tls_options_passes
+    @ldap.host = 'localhost'
+    @ldap.encryption(
+      method:      :start_tls,
+    )
+    assert @ldap.bind(BIND_CREDS),
+           @ldap.get_operation_result.inspect
+  end
+
+  def test_bind_tls_with_valid_hostname_empty_tls_options_passes
+    @ldap.host = 'localhost'
+    @ldap.encryption(
+      method:      :start_tls,
+      tls_options: {},
+    )
+    assert @ldap.bind(BIND_CREDS),
+           @ldap.get_operation_result.inspect
+  end
+
   def test_bind_tls_with_valid_hostname_just_verify_peer_ca_passes
     @ldap.host = 'localhost'
     @ldap.encryption(


### PR DESCRIPTION
I'd like to add these tests since this behavior may be unexpected, in particular for users of the omniauth-ldap gem https://github.com/intridea/omniauth-ldap/blob/master/lib/omniauth-ldap/adaptor.rb#L93).

Additionally, if this behavior changes (for example, by removing `unless tls_options.empty?` https://github.com/ruby-ldap/ruby-net-ldap/pull/161/files#diff-8f385efd0cd6c068dec9c5db605a4d36R51), these tests would fail, and therefore help to ensure that the breaking change is deliberate.

Thanks!