### PR TITLE
Add link to documentation in Readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,7 +21,7 @@ the most recent LDAP RFCs (4510–4519, plus portions of 4520–4532).
 
 == Synopsis
 
-See {Net::LDAP}[https://www.rubydoc.info/gems/ruby-net-ldap/Net/LDAP] for documentation and usage samples.
+See {Net::LDAP}[https://www.rubydoc.info/github/ruby-ldap/ruby-net-ldap/master] for documentation and usage samples.
 
 == Requirements
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -21,7 +21,7 @@ the most recent LDAP RFCs (4510–4519, plus portions of 4520–4532).
 
 == Synopsis
 
-See Net::LDAP for documentation and usage samples.
+See {Net::LDAP}[https://www.rubydoc.info/gems/ruby-net-ldap/Net/LDAP] for documentation and usage samples.
 
 == Requirements
 


### PR DESCRIPTION
This update just adds a link to the documentation in the readme so people can find it without having to Google.