### PR TITLE
CONTRIBUTING.md: Repair link to Issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,6 @@ MyClass.new \
   baz: 'garply'
 ```
 
-[issues]: https://github.com/ruby-net-ldap/ruby-net-ldap/issues
+[issues]: https://github.com/ruby-ldap/ruby-net-ldap/issues
 [pr]: https://help.github.com/articles/using-pull-requests
 [travis]: https://travis-ci.org/ruby-ldap/ruby-net-ldap


### PR DESCRIPTION
This PR fixes the Markdown link to the Issues page.