### PR TITLE
Fixed bug: Skip closing of io socket if it's already closed.

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -81,6 +81,7 @@ class Net::LDAP::Connection #:nodoc:
   module FixSSLSocketSyncClose
     def close
       super
+      return if io.closed?
       io.close
     end
   end

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -81,8 +81,7 @@ class Net::LDAP::Connection #:nodoc:
   module FixSSLSocketSyncClose
     def close
       super
-      return if io.closed?
-      io.close
+      io.close unless io.closed?
     end
   end
 


### PR DESCRIPTION
Hi there!

We're currently experimenting with TCR for mocking LDAP connections. However, I encountered an issue where a `SystemStackError` is raised while closing the (SSL) connection. What basically happens is: *close LDAP connection* -> Close SSL connection -> Close TCR mocked socket + close IO socket -> Close TCR mocked socket ->Close SSL connection -> .... 

This can be easily avoided by checking if the IO socket is already closed before performing a close on it. This is what this PR does.

 Let me know if there are any questions.