### PR TITLE
Add link to generated and hosted documentation on rubydoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,7 +21,7 @@ the most recent LDAP RFCs (4510–4519, plus portions of 4520–4532).
 
 == Synopsis
 
-See Net::LDAP for documentation and usage samples.
+See {Net::LDAP on rubydoc.info}[https://www.rubydoc.info/gems/net-ldap/Net/LDAP] for documentation and usage samples.
 
 == Requirements
 


### PR DESCRIPTION
Fix #318 by adding a link to rubydoc.info.