### PR TITLE
Output cleanup

### DIFF
--- a/Contributors.rdoc
+++ b/Contributors.rdoc
@@ -23,3 +23,4 @@ Contributions since:
 * Cody Cutrer (ccutrer)
 * WoodsBagotAndreMarquesLee
 * Rufus Post (mynameisrufus)
+* Akamai Technologies, Inc. (jwedoff)

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1320,7 +1320,7 @@ class Net::LDAP
     # Force connect to see if there's a connection error
     connection.socket
     connection
-  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Net::LDAP::ConnectionRefusedError => e
+  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
     @result = {
       :resultCode   => 52,
       :errorMessage => ResultStrings[ResultCodeUnavailable],

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -61,7 +61,7 @@ class Net::LDAP::Connection #:nodoc:
           if encryption[:tls_options] &&
              encryption[:tls_options][:verify_mode] &&
              encryption[:tls_options][:verify_mode] == OpenSSL::SSL::VERIFY_NONE
-            ssl_verify_warning_handler(host, port)
+            ssl_verify_warning(host, port)
           else
             @conn.post_connection_check(host)
           end

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -38,6 +38,12 @@ class Net::LDAP::Connection #:nodoc:
     setup_encryption(encryption, timeout) if encryption
   end
 
+  # Internal: simple private method that can be replaced, if necessary, to allow this warning to be modified
+  def ssl_verify_warning(host, port)
+    warn "not verifying SSL hostname of LDAPS server '#{host}:#{port}'"
+  end
+  private :ssl_verify_warning
+
   def open_connection(server)
     hosts = server[:hosts]
     encryption = server[:encryption]
@@ -55,7 +61,7 @@ class Net::LDAP::Connection #:nodoc:
           if encryption[:tls_options] &&
              encryption[:tls_options][:verify_mode] &&
              encryption[:tls_options][:verify_mode] == OpenSSL::SSL::VERIFY_NONE
-            warn "not verifying SSL hostname of LDAPS server '#{host}:#{port}'"
+            ssl_verify_warning_handler(host, port)
           else
             @conn.post_connection_check(host)
           end

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -9,31 +9,11 @@ class Net::LDAP
 
   class AlreadyOpenedError < Error; end
   class SocketError < Error; end
-  class ConnectionRefusedError < Error;
-    def initialize(*args)
-      warn_deprecation_message
-      super
-    end
-
-    def message
-      warn_deprecation_message
-      super
-    end
-
-    private
-
-    def warn_deprecation_message
-      warn "Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead."
-    end
-  end
   class ConnectionError < Error
     def self.new(errors)
       error = errors.first.first
       if errors.size == 1
-        if error.kind_of? Errno::ECONNREFUSED
-          return Net::LDAP::ConnectionRefusedError.new(error.message)
-        end
-
+        return error if error.kind_of? Errno::ECONNREFUSED
         return Net::LDAP::Error.new(error.message)
       end
 

--- a/test/integration/test_bind.rb
+++ b/test/integration/test_bind.rb
@@ -70,7 +70,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
                      ca_file:     CA_FILE },
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -86,7 +86,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
       tls_options: TLS_OPTS.merge(ca_file: CA_FILE),
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -102,7 +102,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
       tls_options: { ca_file: CA_FILE },
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -137,7 +137,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
     @ldap.host = '127.0.0.1'
     @ldap.encryption(method: :start_tls, tls_options: {})
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(

--- a/test/integration/test_password_modify.rb
+++ b/test/integration/test_password_modify.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 class TestPasswordModifyIntegration < LDAPIntegrationTestCase
   def setup
     super
-    @admin_account = {dn: 'cn=admin,dc=rubyldap,dc=com', password: 'passworD1', method: :simple}
+    @admin_account = { dn: 'cn=admin,dc=rubyldap,dc=com', password: 'passworD1', method: :simple }
     @ldap.authenticate @admin_account[:dn], @admin_account[:password]
 
     @dn = 'uid=modify-password-user1,ou=People,dc=rubyldap,dc=com'

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -61,7 +61,7 @@ class TestLDAPConnection < Test::Unit::TestCase
 
     ldap_client = Net::LDAP.new(host: '127.0.0.1', port: 12345)
 
-    assert_raise Net::LDAP::ConnectionRefusedError do
+    assert_raise Errno::ECONNREFUSED do
       ldap_client.bind(method: :simple, username: 'asdf', password: 'asdf')
     end
 
@@ -86,11 +86,10 @@ class TestLDAPConnection < Test::Unit::TestCase
   def test_connection_refused
     connection = Net::LDAP::Connection.new(:host => "fail.Errno::ECONNREFUSED", :port => 636, :socket_class => FakeTCPSocket)
     stderr = capture_stderr do
-      assert_raise Net::LDAP::ConnectionRefusedError do
+      assert_raise Errno::ECONNREFUSED do
         connection.socket
       end
     end
-    assert_equal("Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead.\n",  stderr)
   end
 
   def test_connection_timeout


### PR DESCRIPTION
Remove Net::LDAP::ConnectionRefusedError, and add ssl_verify_warning method (that can be over ridden in tests) to make tests using this library less noisy.