### PR TITLE
Net::LDAP#open does not cache bind result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ publish/
 Gemfile.lock
 .bundle
 bin/
+.idea

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -712,7 +712,7 @@ class Net::LDAP
       begin
         @open_connection = new_connection
         payload[:connection] = @open_connection
-        payload[:bind]       = @open_connection.bind(@auth)
+        payload[:bind]       = @result = @open_connection.bind(@auth)
         yield self
       ensure
         @open_connection.close if @open_connection

--- a/script/install-openldap
+++ b/script/install-openldap
@@ -15,7 +15,7 @@ TMPDIR=$(mktemp -d)
 cd $TMPDIR
 
 # Delete data and reconfigure.
-cp -v /var/lib/ldap/DB_CONFIG ./DB_CONFIG
+cp -v /usr/share/slapd/DB_CONFIG ./DB_CONFIG
 rm -rf /etc/ldap/slapd.d/*
 rm -rf /var/lib/ldap/*
 cp -v ./DB_CONFIG /var/lib/ldap/DB_CONFIG

--- a/test/integration/test_return_codes.rb
+++ b/test/integration/test_return_codes.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 
 class TestReturnCodeIntegration < LDAPIntegrationTestCase
   def test_open_error
-    @ldap.authenticate "fake", "creds"
+    @ldap.authenticate "cn=fake", "creds"
     @ldap.open do
       result = @ldap.get_operation_result
       assert_equal Net::LDAP::ResultCodeInvalidCredentials, result.code

--- a/test/integration/test_return_codes.rb
+++ b/test/integration/test_return_codes.rb
@@ -4,6 +4,14 @@ require_relative '../test_helper'
 # See: section 12.12 http://www.openldap.org/doc/admin24/overlays.html
 
 class TestReturnCodeIntegration < LDAPIntegrationTestCase
+  def test_open_error
+    @ldap.authenticate "fake", "creds"
+    @ldap.open do
+      result = @ldap.get_operation_result
+      assert_equal Net::LDAP::ResultCodeInvalidCredentials, result.code
+    end
+  end
+
   def test_operations_error
     refute @ldap.search(filter: "cn=operationsError", base: "ou=Retcodes,dc=rubyldap,dc=com")
     assert result = @ldap.get_operation_result


### PR DESCRIPTION
We identified that clients cannot safely rely on `Net::LDAP#get_operation_result` when using `Net::LDAP#open` because `@result` is not set.

As a consequence, clients calling `Net::LDAP#get_operation_result` would get the previous cached `@result`. Yikes.