### PR TITLE
Net::LDAP#open does not cache bind result

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -712,7 +712,7 @@ class Net::LDAP
       begin
         @open_connection = new_connection
         payload[:connection] = @open_connection
-        payload[:bind]       = @open_connection.bind(@auth)
+        payload[:bind]       = @result = @open_connection.bind(@auth)
         yield self
       ensure
         @open_connection.close if @open_connection

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -712,7 +712,7 @@ class Net::LDAP
       begin
         @open_connection = new_connection
         payload[:connection] = @open_connection
-        payload[:bind]       = @result = @open_connection.bind(@auth)
+        payload[:bind]       = @open_connection.bind(@auth)
         yield self
       ensure
         @open_connection.close if @open_connection

--- a/lib/net/ldap/version.rb
+++ b/lib/net/ldap/version.rb
@@ -1,5 +1,5 @@
 module Net
   class LDAP
-    VERSION = "0.16.1"
+    VERSION = "0.16.2"
   end
 end

--- a/test/integration/test_return_codes.rb
+++ b/test/integration/test_return_codes.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 
 class TestReturnCodeIntegration < LDAPIntegrationTestCase
   def test_open_error
-    @ldap.authenticate "fake", "creds"
+    @ldap.authenticate "cn=fake", "creds"
     @ldap.open do
       result = @ldap.get_operation_result
       assert_equal Net::LDAP::ResultCodeInvalidCredentials, result.code

--- a/test/integration/test_return_codes.rb
+++ b/test/integration/test_return_codes.rb
@@ -4,6 +4,14 @@ require_relative '../test_helper'
 # See: section 12.12 http://www.openldap.org/doc/admin24/overlays.html
 
 class TestReturnCodeIntegration < LDAPIntegrationTestCase
+  def test_open_error
+    @ldap.authenticate "fake", "creds"
+    @ldap.open do
+      result = @ldap.get_operation_result
+      assert_equal Net::LDAP::ResultCodeInvalidCredentials, result.code
+    end
+  end
+
   def test_operations_error
     refute @ldap.search(filter: "cn=operationsError", base: "ou=Retcodes,dc=example,dc=org")
     assert result = @ldap.get_operation_result


### PR DESCRIPTION
Hi friends 👋 this is a follow up to https://github.com/ruby-ldap/ruby-net-ldap/pull/331, same fix, but including the fixed CI build 🎉 

# What

I identified that clients cannot safely rely on [`Net::LDAP#get_operation_result`](https://github.com/vroldanbet/ruby-net-ldap/blob/3455b3021fd966cee9af67a6a456f7a5ad6373fb/lib/net/ldap.rb#L666) when using [`Net::LDAP#open`](https://github.com/vroldanbet/ruby-net-ldap/blob/3455b3021fd966cee9af67a6a456f7a5ad6373fb/lib/net/ldap.rb#L704) because `@result` is not set. As a consequence, clients calling [`Net::LDAP#get_operation_result`](https://github.com/vroldanbet/ruby-net-ldap/blob/3455b3021fd966cee9af67a6a456f7a5ad6373fb/lib/net/ldap.rb#L666) would get the previous cached `@result`. Yikes 🙀 

# How

The solution is simple: to cache `@result` accordingly, [like other methods in the class do](https://github.com/vroldanbet/ruby-net-ldap/blob/92be7104d3a33b860f6f688bb3360ecefbf51339/lib/net/ldap.rb#L783). You can see the 🐛 reproduced in https://github.com/ruby-ldap/ruby-net-ldap/pull/334/commits/ab18e5b11ca38ad93eb8fdf64f01e2ed8334adc8. The test is https://github.com/ruby-ldap/ruby-net-ldap/pull/334/commits/8ba3f95e983c42a7328d73de19fde570fb517f05

```
<49> expected but was <0>
```

And then going 🍏 in https://github.com/ruby-ldap/ruby-net-ldap/pull/334/commits/92be7104d3a33b860f6f688bb3360ecefbf51339

# Assumptions

It's not clear to me if this was an intentional design choice. Maybe no one was meant to call [`Net::LDAP#get_operation_result`](https://github.com/vroldanbet/ruby-net-ldap/blob/3455b3021fd966cee9af67a6a456f7a5ad6373fb/lib/net/ldap.rb#L666) after [`Net::LDAP#open`](https://github.com/vroldanbet/ruby-net-ldap/blob/3455b3021fd966cee9af67a6a456f7a5ad6373fb/lib/net/ldap.rb#L704)? If that's the case, I couldn't find any evidence.

I see [there are some comments](https://github.com/vroldanbet/ruby-net-ldap/blob/3455b3021fd966cee9af67a6a456f7a5ad6373fb/lib/net/ldap.rb#L705-L706) explicitly calling out the result is deliberately ignored ¯\_(ツ)_/¯