### PR TITLE
Fix uninitialised Net::LDAP::LdapPduError

### DIFF
--- a/lib/net/ldap/pdu.rb
+++ b/lib/net/ldap/pdu.rb
@@ -123,7 +123,7 @@ class Net::LDAP::PDU
     when ExtendedResponse
       parse_extended_response(ber_object[1])
     else
-      raise LdapPduError.new("unknown pdu-type: #{@app_tag}")
+      raise Error.new("unknown pdu-type: #{@app_tag}")
     end
 
     parse_controls(ber_object[2]) if ber_object[2]


### PR DESCRIPTION
Due to missing explicit name, the `LdapPduError` actually looked for `Net::LDAP::PDU::LdapPduError` class.

Even though the `Net` module has a missing constant method, it was not catched here.

The solution is to explicitly use `Error` classs.