### PR TITLE
add explicit ** to silence Ruby 2.7 warning

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -710,7 +710,7 @@ class Net::LDAP::Connection #:nodoc:
   # Wrap around Socket.tcp to normalize with other Socket initializers
   class DefaultSocket
     def self.new(host, port, socket_opts = {})
-      Socket.tcp(host, port, socket_opts)
+      Socket.tcp(host, port, **socket_opts)
     end
   end
 end # class Connection


### PR DESCRIPTION
Closes https://github.com/ruby-ldap/ruby-net-ldap/issues/341