### PR TITLE
Don't verify hostname when verify_hostname is false in tls_options

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -53,8 +53,10 @@ class Net::LDAP::Connection #:nodoc:
         prepare_socket(server.merge(socket: @socket_class.new(host, port, socket_opts)), timeout)
         if encryption
           if encryption[:tls_options] &&
-             encryption[:tls_options][:verify_mode] &&
-             encryption[:tls_options][:verify_mode] == OpenSSL::SSL::VERIFY_NONE
+             (encryption[:tls_options][:verify_mode] &&
+              encryption[:tls_options][:verify_mode] == OpenSSL::SSL::VERIFY_NONE ||
+              encryption[:tls_options].key?(:verify_hostname) &&
+              encryption[:tls_options][:verify_hostname] == false)
             warn "not verifying SSL hostname of LDAPS server '#{host}:#{port}'"
           else
             @conn.post_connection_check(host)

--- a/test/integration/test_bind.rb
+++ b/test/integration/test_bind.rb
@@ -47,6 +47,26 @@ class TestBindIntegration < LDAPIntegrationTestCase
            @ldap.get_operation_result.inspect
   end
 
+  def test_bind_tls_with_bad_hostname_no_verify_hostname_no_ca_passes
+    @ldap.host = INTEGRATION_HOSTNAME
+    @ldap.encryption(
+      method:      :start_tls,
+      tls_options: { verify_hostname: false },
+    )
+    assert @ldap.bind(BIND_CREDS),
+           @ldap.get_operation_result.inspect
+  end
+
+  def test_bind_tls_with_bad_hostname_no_verify_hostname_no_ca_opt_merge_passes
+    @ldap.host = '127.0.0.1'
+    @ldap.encryption(
+      method:      :start_tls,
+      tls_options: TLS_OPTS.merge(verify_hostname: false),
+    )
+    assert @ldap.bind(BIND_CREDS),
+           @ldap.get_operation_result.inspect
+  end
+
   def test_bind_tls_with_bad_hostname_verify_none_no_ca_passes
     @ldap.host = INTEGRATION_HOSTNAME
     @ldap.encryption(


### PR DESCRIPTION
https://ruby.github.io/openssl/OpenSSL/SSL/SSLContext.html documents the option `verify_hostname` as whether to check the server certificate is valid for the hostname.

But when I set `verify_hostname` to `false` in `tls_options`, it has no effect, it still reports the error "hostname does not match the server certificate".

Then I found this is the result of #259 but the assumption is wrong that users who don't care about hostname validation should set `verify_mode` to `OpenSSL::SSL::VERIFY_NONE`. This disables the certificate validation completely. Maybe the reason why #259 didn't add a check for `verify_hostname` is because `verify_hostname` was added later in https://github.com/ruby/openssl/pull/60 (i.e. the same year but a few months later).

So for more fine-grained configuration to disable only hostname verification without disabling certificate validation, here is this pull request.