### PR TITLE
lib/net/ldap/connections.rb: use ** to pass a keyword parameter

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -710,7 +710,7 @@ class Net::LDAP::Connection #:nodoc:
   # Wrap around Socket.tcp to normalize with other Socket initializers
   class DefaultSocket
     def self.new(host, port, socket_opts = {})
-      Socket.tcp(host, port, socket_opts)
+      Socket.tcp(host, port, **socket_opts)
     end
   end
 end # class Connection


### PR DESCRIPTION
In Socket.tcp call is passed a keyword parameter as is and while I've
been testing a library that relies on it I got the following warning:

net/ldap/connection.rb:709: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

In ruby 2.7 is preferred to use ** to pass keyword arguments in method's
call.