### PR TITLE
simplify encoding logic: no more chomping required

### DIFF
--- a/lib/net/ldap/password.rb
+++ b/lib/net/ldap/password.rb
@@ -22,12 +22,12 @@ class Net::LDAP::Password
     def generate(type, str)
       case type
       when :md5
-         '{MD5}' + Base64.encode64(Digest::MD5.digest(str)).chomp!
+         '{MD5}' + Base64.strict_encode64(Digest::MD5.digest(str))
       when :sha
-         '{SHA}' + Base64.encode64(Digest::SHA1.digest(str)).chomp!
+         '{SHA}' + Base64.strict_encode64(Digest::SHA1.digest(str))
       when :ssha
          salt = SecureRandom.random_bytes(16)
-         '{SSHA}' + Base64.encode64(Digest::SHA1.digest(str + salt) + salt).chomp!
+         '{SSHA}' + Base64.strict_encode64(Digest::SHA1.digest(str + salt) + salt)
       else
          raise Net::LDAP::HashTypeUnsupportedError, "Unsupported password-hash type (#{type})"
       end


### PR DESCRIPTION
As per https://github.com/ruby-ldap/ruby-net-ldap/pull/326#discussion_r449285470

> I think https://ruby-doc.org/stdlib/libdoc/base64/rdoc/Base64.html#method-i-strict_encode64 would make this even more simple and not require calling `#chomp`

All done now... test still pass!  👍 