### PR TITLE
CI: Drop rbx-2, uninstallable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ rvm:
   - ruby-head
   - jruby-19mode
   - jruby-head
-  - rbx-2
 
 addons:
   hosts:
@@ -50,7 +49,6 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-19mode
     - rvm: jruby-head
-    - rvm: rbx-2
   fast_finish: true
 
 notifications:


### PR DESCRIPTION
The rbx-4 does no longer install, either, so I figured it would be easier to drop that from the matrix.

Example output from Travis CI:

> 13.45s $ rvm use rbx-2 --install --binary --fuzzy
> curl: (22) The requested URL returned error: 404 Not Found
> Required rbx-2 is not installed - installing.
> curl: (22) The requested URL returned error: 404 Not Found
> Searching for binary rubies, this might take some time.
> Requested binary installation but no rubies are available to download, consider skipping --binary flag.
> Gemset '' does not exist, 'rvm rbx-2 do rvm gemset create ' first, or append '--create'.
> The command "rvm use rbx-2 --install --binary --fuzzy" failed and exited with 2 during .