### PR TITLE
Address some warnings and fix JRuby test omissions

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -490,7 +490,7 @@ class Net::LDAP::Filter
     when :eq
       if @right == "*" # presence test
         @left.to_s.to_ber_contextspecific(7)
-      elsif @right =~ /[*]/ # substring
+      elsif @right.to_s =~ /[*]/ # substring
         # Parsing substrings is a little tricky. We use String#split to
         # break a string into substrings delimited by the * (star)
         # character. But we also need to know whether there is a star at the

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -95,7 +95,7 @@ class TestLDAPConnection < Test::Unit::TestCase
 
   def test_connection_timeout
     connection = Net::LDAP::Connection.new(:host => "fail.Errno::ETIMEDOUT", :port => 636, :socket_class => FakeTCPSocket)
-    stderr = capture_stderr do
+    capture_stderr do
       assert_raise Net::LDAP::Error do
         connection.socket
       end

--- a/test/test_snmp.rb
+++ b/test/test_snmp.rb
@@ -17,7 +17,7 @@ class TestSnmp < Test::Unit::TestCase
   def test_invalid_packet
     data = "xxxx"
     assert_raise(Net::BER::BerError) do
-      ary = data.read_ber(Net::SNMP::AsnSyntax)
+      data.read_ber(Net::SNMP::AsnSyntax)
     end
   end
 

--- a/test/test_ssl_ber.rb
+++ b/test/test_ssl_ber.rb
@@ -30,15 +30,13 @@ class TestSSLBER < Test::Unit::TestCase
   end
 
   def test_transmit_strings
-    omit "JRuby throws an error without a real socket"
-    omit_if RUBY_PLATFORM == "java"
+    omit_if RUBY_PLATFORM == "java", "JRuby throws an error without a real socket"
 
     assert_equal "foo", transmit("foo")
   end
 
   def test_transmit_ber_encoded_numbers
-    omit "JRuby throws an error without a real socket"
-    omit_if RUBY_PLATFORM == "java"
+    omit_if RUBY_PLATFORM == "java", "JRuby throws an error without a real socket"
 
     @to.write 1234.to_ber
     assert_equal 1234, @from.read_ber


### PR DESCRIPTION
```
ruby-net-ldap/test/test_ldap_connection.rb:98: warning: assigned but unused variable - stderr
ruby-net-ldap/test/test_search.rb:34: warning: assigned but unused variable - result
ruby-net-ldap/test/test_snmp.rb:20: warning: assigned but unused variable - ary

ruby-net-ldap/lib/net/ldap/filter.rb:493: warning: deprecated Object#=~ is called on Integer; it always returns nil
```