### PR TITLE
Remove deprecated ConnectionRefusedError

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1320,7 +1320,7 @@ class Net::LDAP
     # Force connect to see if there's a connection error
     connection.socket
     connection
-  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Net::LDAP::ConnectionRefusedError => e
+  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
     @result = {
       :resultCode   => 52,
       :errorMessage => ResultStrings[ResultCodeUnavailable],

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -9,30 +9,11 @@ class Net::LDAP
 
   class AlreadyOpenedError < Error; end
   class SocketError < Error; end
-  class ConnectionRefusedError < Error;
-    def initialize(*args)
-      warn_deprecation_message
-      super
-    end
-
-    def message
-      warn_deprecation_message
-      super
-    end
-
-    private
-
-    def warn_deprecation_message
-      warn "Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead."
-    end
-  end
   class ConnectionError < Error
     def self.new(errors)
       error = errors.first.first
       if errors.size == 1
-        if error.kind_of? Errno::ECONNREFUSED
-          return Net::LDAP::ConnectionRefusedError.new(error.message)
-        end
+        return error if error.is_a? Errno::ECONNREFUSED
 
         return Net::LDAP::Error.new(error.message)
       end

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -1,10 +1,4 @@
 class Net::LDAP
-  class LdapError < StandardError
-    def message
-      "Deprecation warning: Net::LDAP::LdapError is no longer used. Use Net::LDAP::Error or rescue one of it's subclasses. \n" + super
-    end
-  end
-
   class Error < StandardError; end
 
   class AlreadyOpenedError < Error; end

--- a/test/integration/test_bind.rb
+++ b/test/integration/test_bind.rb
@@ -1,7 +1,6 @@
 require_relative '../test_helper'
 
 class TestBindIntegration < LDAPIntegrationTestCase
-
   INTEGRATION_HOSTNAME = 'ldap.example.org'.freeze
 
   def test_bind_success
@@ -28,7 +27,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
     assert_equal Net::LDAP::ResultCodeUnwillingToPerform, result.code
     assert_equal Net::LDAP::ResultStrings[Net::LDAP::ResultCodeUnwillingToPerform], result.message
     assert_equal "unauthenticated bind (DN with no password) disallowed",
-      result.error_message
+                 result.error_message
     assert_equal "", result.matched_dn
   end
 
@@ -75,7 +74,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
                      ca_file:     CA_FILE },
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -91,7 +90,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
       tls_options: TLS_OPTS.merge(ca_file: CA_FILE),
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -107,7 +106,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
       tls_options: { ca_file: CA_FILE },
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -142,7 +141,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
     @ldap.host = '127.0.0.1'
     @ldap.encryption(method: :start_tls, tls_options: {})
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -61,7 +61,7 @@ class TestLDAPConnection < Test::Unit::TestCase
 
     ldap_client = Net::LDAP.new(host: '127.0.0.1', port: 12345)
 
-    assert_raise Net::LDAP::ConnectionRefusedError do
+    assert_raise Errno::ECONNREFUSED do
       ldap_client.bind(method: :simple, username: 'asdf', password: 'asdf')
     end
 
@@ -86,11 +86,10 @@ class TestLDAPConnection < Test::Unit::TestCase
   def test_connection_refused
     connection = Net::LDAP::Connection.new(:host => "fail.Errno::ECONNREFUSED", :port => 636, :socket_class => FakeTCPSocket)
     stderr = capture_stderr do
-      assert_raise Net::LDAP::ConnectionRefusedError do
+      assert_raise Errno::ECONNREFUSED do
         connection.socket
       end
     end
-    assert_equal("Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead.\n",  stderr)
   end
 
   def test_connection_timeout


### PR DESCRIPTION
ConnectionError.new was returning a deprecated ConnectionRefusedError,
this pattern was introduced for backward compatibility at some point,
but there seems to be no other usage of `ConnectionRefusedError` needed in
the codebase.

If we need to keep the class around for external backward
compatibility, I would recommend that we introduce a private-ish way to
initialize `ConnectionRefusedError` without raising the deprecation
warning.

I'm happy to PR such a change, but it seems that we could bump the
version and get rid of this deprecation in the library.

`LdapError` was no longer used internally so has been removed in this PR.

This PR is a semi-duplicate of https://github.com/ruby-ldap/ruby-net-ldap/pull/322/files, which I found after making the changes locally, but it's quite old and the author may not have the required context anymore and there are some conflicts, so I decided to open this PR anyway.