### PR TITLE
changes to implement timeouts with non-blocking reads and writes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -206,7 +206,7 @@ Lint/UselessAssignment:
 
 # Offense count: 48
 Metrics/AbcSize:
-  Max: 116
+  Max: 118
 
 # Offense count: 4
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -221,7 +221,7 @@ Metrics/BlockNesting:
 # Offense count: 11
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 429
+  Max: 436
 
 # Offense count: 23
 Metrics/CyclomaticComplexity:

--- a/Contributors.rdoc
+++ b/Contributors.rdoc
@@ -23,3 +23,4 @@ Contributions since:
 * Cody Cutrer (ccutrer)
 * WoodsBagotAndreMarquesLee
 * Rufus Post (mynameisrufus)
+* Akamai Technologies, Inc. (jwedoff)

--- a/lib/net/ber/ber_parser_nonblock.rb
+++ b/lib/net/ber/ber_parser_nonblock.rb
@@ -1,0 +1,118 @@
+# Implements nonbocking and timeout handling routines for BER parsing.
+module Net::BER::BERParserNonblock
+  # Internal: Returns the BER message ID or nil.
+  def read_ber_id
+    ber_timeout_getbyte
+  end
+  private :read_ber_id
+
+  # Internal: specify the BER socket read timeouts, nil by default (no timeout).
+  attr_accessor :ber_io_deadline
+  private :ber_io_deadline
+
+  ##
+  # sets a timeout of timeout seconds for read_ber and ber_timeout_write operations in the provided block the proin the future for if there is not already a earlier deadline set
+  def with_timeout(timeout)
+    timeout = timeout.to_f
+    # don't change deadline if run without timeout
+    return yield if timeout <= 0
+    # clear deadline if it is not in the future
+    self.ber_io_deadline = nil unless ber_io_timeout.to_f > 0
+    new_deadline = Time.now + timeout
+    # don't add deadline if current deadline is shorter
+    return yield if ber_io_deadline && ber_io_deadline < new_deadline
+    old_deadline = ber_io_deadline
+    begin
+      self.ber_io_deadline = new_deadline
+      yield
+    ensure
+      self.ber_io_deadline = old_deadline
+    end
+  end
+
+  # seconds until ber_io_deadline
+  def ber_io_timeout
+    ber_io_deadline ? ber_io_deadline - Time.now : nil
+  end
+  private :ber_io_timeout
+
+  def read_select!
+    return if IO.select([self], nil, nil, ber_io_timeout)
+    raise Errno::ETIMEDOUT, "Timed out reading from the socket"
+  end
+  private :read_select!
+
+  def write_select!
+    return if IO.select(nil, [self], nil, ber_io_timeout)
+    raise Errno::ETIMEDOUT, "Timed out reading from the socket"
+  end
+  private :write_select!
+
+  # Internal: Replaces `getbyte` with nonblocking implementation.
+  def ber_timeout_getbyte
+    read_nonblock(1).ord
+  rescue IO::WaitReadable
+    read_select!
+    retry
+  rescue IO::WaitWritable
+    write_select!
+    retry
+  rescue EOFError
+    # nothing to read on the socket (StringIO)
+    nil
+  end
+  private :ber_timeout_getbyte
+
+  # Internal: Read `len` bytes, respecting timeout.
+  def ber_timeout_read(len)
+    buffer ||= ''.force_encoding(Encoding::ASCII_8BIT)
+    begin
+      read_nonblock(len, buffer)
+      return buffer if buffer.bytesize >= len
+    rescue IO::WaitReadable, IO::WaitWritable
+      buffer.clear
+    rescue EOFError
+      # nothing to read on the socket (StringIO)
+      nil
+    end
+    block ||= ''.force_encoding(Encoding::ASCII_8BIT)
+    len -= buffer.bytesize
+    loop do
+      begin
+        read_nonblock(len, block)
+      rescue IO::WaitReadable
+        read_select!
+        retry
+      rescue IO::WaitWritable
+        write_select!
+        retry
+      rescue EOFError
+        return buffer.empty? ? nil : buffer
+      end
+      buffer << block
+      len -= block.bytesize
+      return buffer if len <= 0
+    end
+  end
+  private :ber_timeout_read
+
+  ##
+  # Writes val as a plain write would, but respecting the dealine set by with_timeout
+  def ber_timeout_write(val)
+    total_written = 0
+    while val.bytesize > 0
+      begin
+        written = write_nonblock(val)
+      rescue IO::WaitReadable
+        read_select!
+        retry
+      rescue IO::WaitWritable
+        write_select!
+        retry
+      end
+      total_written += written
+      val = val.byteslice(written..-1)
+    end
+    total_written
+  end
+end

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -553,6 +553,7 @@ class Net::LDAP
     @force_no_page = args[:force_no_page] || DefaultForceNoPage
     @encryption = normalize_encryption(args[:encryption]) # may be nil
     @connect_timeout = args[:connect_timeout]
+    @io_timeout = args[:io_timeout]
 
     if pr = @auth[:password] and pr.respond_to?(:call)
       @auth[:password] = pr.call
@@ -1293,14 +1294,19 @@ class Net::LDAP
   # result from that, and :use_connection: will not yield at all. If not
   # the return value is whatever is returned from the block.
   def use_connection(args)
+    timeout_args = args.key?(:io_timeout) ? [args[:io_timeout]] : []
     if @open_connection
-      yield @open_connection
+      @open_connection.with_timeout(*timeout_args) do
+        yield(@open_connection)
+      end
     else
       begin
         conn = new_connection
-        result = conn.bind(args[:auth] || @auth)
-        return result unless result.result_code == Net::LDAP::ResultCodeSuccess
-        yield conn
+        conn.with_timeout(*timeout_args) do
+          result = conn.bind(args[:auth] || @auth)
+          return result unless result.result_code == Net::LDAP::ResultCodeSuccess
+          yield(conn)
+        end
       ensure
         conn.close if conn
       end
@@ -1315,7 +1321,8 @@ class Net::LDAP
       :hosts                   => @hosts,
       :encryption              => @encryption,
       :instrumentation_service => @instrumentation_service,
-      :connect_timeout         => @connect_timeout
+      :connect_timeout         => @connect_timeout,
+      :io_timeout              => @io_timeout
 
     # Force connect to see if there's a connection error
     connection.socket

--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -261,7 +261,7 @@ class Net::LDAP::Connection #:nodoc:
   def write(request, controls = nil, message_id = next_msgid)
     instrument "write.net_ldap_connection" do |payload|
       packet = [message_id.to_ber, request, controls].compact.to_ber_sequence
-      payload[:content_length] = socket.write(packet)
+      payload[:content_length] = socket.ber_timeout_write(packet)
     end
   end
   private :write
@@ -271,11 +271,19 @@ class Net::LDAP::Connection #:nodoc:
     @msgid += 1
   end
 
+  ##
+  # calls with_timeout on socket, with timeout defaulting to the :io_timeout parameter
+  def with_timeout(timeout=@server[:io_timeout], &block)
+    socket.with_timeout(timeout, &block)
+  end
+
   def bind(auth)
-    instrument "bind.net_ldap_connection" do |payload|
-      payload[:method] = meth = auth[:method]
-      adapter = Net::LDAP::AuthAdapter[meth]
-      adapter.new(self).bind(auth)
+    with_timeout do
+      instrument "bind.net_ldap_connection" do |payload|
+        payload[:method] = meth = auth[:method]
+        adapter = Net::LDAP::AuthAdapter[meth]
+        adapter.new(self).bind(auth)
+      end
     end
   end
 
@@ -305,6 +313,17 @@ class Net::LDAP::Connection #:nodoc:
       false.to_ber,
       sort_control_values.to_ber_sequence.to_s.to_ber,
     ].to_ber_sequence
+  end
+
+  # --
+  # return a timeout given the value for time (if provided)
+  # defaults to using io_timeout
+  def calculate_timeout(time)
+    if time > 0
+      time + 0.5 #give remote server half a second to respond before killing connection
+    else
+      @server[:io_timeout]
+    end
   end
 
   #--
@@ -385,6 +404,8 @@ class Net::LDAP::Connection #:nodoc:
 
     message_id = next_msgid
 
+    timeout = calculate_timeout(time)
+
     instrument "search.net_ldap_connection",
                message_id: message_id,
                filter:     filter,
@@ -396,115 +417,116 @@ class Net::LDAP::Connection #:nodoc:
                referrals:  refs,
                deref:      deref,
                attributes: attrs do |payload|
-      loop do
-        # should collect this into a private helper to clarify the structure
-        query_limit = 0
-        if size > 0
-          query_limit = if paged
-                          (((size - n_results) < 126) ? (size - n_results) : 0)
-                        else
-                          size
-                        end
-        end
-
-        request = [
-          base.to_ber,
-          scope.to_ber_enumerated,
-          deref.to_ber_enumerated,
-          query_limit.to_ber, # size limit
-          time.to_ber,
-          attrs_only.to_ber,
-          filter.to_ber,
-          ber_attrs.to_ber_sequence,
-        ].to_ber_appsequence(Net::LDAP::PDU::SearchRequest)
-
-        # rfc2696_cookie sometimes contains binary data from Microsoft Active Directory
-        # this breaks when calling to_ber. (Can't force binary data to UTF-8)
-        # we have to disable paging (even though server supports it) to get around this...
-
-        controls = []
-        controls <<
-          [
-            Net::LDAP::LDAPControls::PAGED_RESULTS.to_ber,
-            # Criticality MUST be false to interoperate with normal LDAPs.
-            false.to_ber,
-            rfc2696_cookie.map(&:to_ber).to_ber_sequence.to_s.to_ber,
-          ].to_ber_sequence if paged
-        controls << ber_sort if ber_sort
-        controls = controls.empty? ? nil : controls.to_ber_contextspecific(0)
-
-        write(request, controls, message_id)
-
-        result_pdu = nil
-        controls = []
-
-        while pdu = queued_read(message_id)
-          case pdu.app_tag
-          when Net::LDAP::PDU::SearchReturnedData
-            n_results += 1
-            yield pdu.search_entry if block_given?
-          when Net::LDAP::PDU::SearchResultReferral
-            if refs
-              if block_given?
-                se = Net::LDAP::Entry.new
-                se[:search_referrals] = (pdu.search_referrals || [])
-                yield se
-              end
-            end
-          when Net::LDAP::PDU::SearchResult
-            result_pdu = pdu
-            controls = pdu.result_controls
-            if refs && pdu.result_code == Net::LDAP::ResultCodeReferral
-              if block_given?
-                se = Net::LDAP::Entry.new
-                se[:search_referrals] = (pdu.search_referrals || [])
-                yield se
-              end
-            end
-            break
-          else
-            raise Net::LDAP::ResponseTypeInvalidError, "invalid response-type in search: #{pdu.app_tag}"
+      with_timeout(timeout) do
+        loop do
+          # should collect this into a private helper to clarify the structure
+          query_limit = 0
+          if size > 0
+            query_limit = if paged
+                            (((size - n_results) < 126) ? (size - n_results) : 0)
+                          else
+                            size
+                          end
           end
-        end
 
-        if result_pdu.nil?
-          raise Net::LDAP::ResponseMissingOrInvalidError, "response missing"
-        end
+          request = [
+            base.to_ber,
+            scope.to_ber_enumerated,
+            deref.to_ber_enumerated,
+            query_limit.to_ber, # size limit
+            time.to_ber,
+            attrs_only.to_ber,
+            filter.to_ber,
+            ber_attrs.to_ber_sequence,
+          ].to_ber_appsequence(Net::LDAP::PDU::SearchRequest)
 
-        # count number of pages of results
-        payload[:page_count] ||= 0
-        payload[:page_count]  += 1
+          # rfc2696_cookie sometimes contains binary data from Microsoft Active Directory
+          # this breaks when calling to_ber. (Can't force binary data to UTF-8)
+          # we have to disable paging (even though server supports it) to get around this...
 
-        # When we get here, we have seen a type-5 response. If there is no
-        # error AND there is an RFC-2696 cookie, then query again for the next
-        # page of results. If not, we're done. Don't screw this up or we'll
-        # break every search we do.
-        #
-        # Noticed 02Sep06, look at the read_ber call in this loop, shouldn't
-        # that have a parameter of AsnSyntax? Does this just accidentally
-        # work? According to RFC-2696, the value expected in this position is
-        # of type OCTET STRING, covered in the default syntax supported by
-        # read_ber, so I guess we're ok.
-        more_pages = false
-        if result_pdu.result_code == Net::LDAP::ResultCodeSuccess and controls
-          controls.each do |c|
-            if c.oid == Net::LDAP::LDAPControls::PAGED_RESULTS
-              # just in case some bogus server sends us more than 1 of these.
-              more_pages = false
-              if c.value and c.value.length > 0
-                cookie = c.value.read_ber[1]
-                if cookie and cookie.length > 0
-                  rfc2696_cookie[1] = cookie
-                  more_pages = true
+          controls = []
+          controls <<
+            [
+              Net::LDAP::LDAPControls::PAGED_RESULTS.to_ber,
+              # Criticality MUST be false to interoperate with normal LDAPs.
+              false.to_ber,
+              rfc2696_cookie.map(&:to_ber).to_ber_sequence.to_s.to_ber,
+            ].to_ber_sequence if paged
+          controls << ber_sort if ber_sort
+          controls = controls.empty? ? nil : controls.to_ber_contextspecific(0)
+
+          write(request, controls, message_id)
+
+          result_pdu = nil
+          controls = []
+
+          while pdu = queued_read(message_id)
+            case pdu.app_tag
+            when Net::LDAP::PDU::SearchReturnedData
+              n_results += 1
+              yield pdu.search_entry if block_given?
+            when Net::LDAP::PDU::SearchResultReferral
+              if refs
+                if block_given?
+                  se = Net::LDAP::Entry.new
+                  se[:search_referrals] = (pdu.search_referrals || [])
+                  yield se
+                end
+              end
+            when Net::LDAP::PDU::SearchResult
+              result_pdu = pdu
+              controls = pdu.result_controls
+              if refs && pdu.result_code == Net::LDAP::ResultCodeReferral
+                if block_given?
+                  se = Net::LDAP::Entry.new
+                  se[:search_referrals] = (pdu.search_referrals || [])
+                  yield se
+                end
+              end
+              break
+            else
+              raise Net::LDAP::ResponseTypeInvalidError, "invalid response-type in search: #{pdu.app_tag}"
+            end
+          end
+
+          if result_pdu.nil?
+            raise Net::LDAP::ResponseMissingOrInvalidError, "response missing"
+          end
+
+          # count number of pages of results
+          payload[:page_count] ||= 0
+          payload[:page_count]  += 1
+
+          # When we get here, we have seen a type-5 response. If there is no
+          # error AND there is an RFC-2696 cookie, then query again for the next
+          # page of results. If not, we're done. Don't screw this up or we'll
+          # break every search we do.
+          #
+          # Noticed 02Sep06, look at the read_ber call in this loop, shouldn't
+          # that have a parameter of AsnSyntax? Does this just accidentally
+          # work? According to RFC-2696, the value expected in this position is
+          # of type OCTET STRING, covered in the default syntax supported by
+          # read_ber, so I guess we're ok.
+          more_pages = false
+          if result_pdu.result_code == Net::LDAP::ResultCodeSuccess and controls
+            controls.each do |c|
+              if c.oid == Net::LDAP::LDAPControls::PAGED_RESULTS
+                # just in case some bogus server sends us more than 1 of these.
+                more_pages = false
+                if c.value and c.value.length > 0
+                  cookie = c.value.read_ber[1]
+                  if cookie and cookie.length > 0
+                    rfc2696_cookie[1] = cookie
+                    more_pages = true
+                  end
                 end
               end
             end
           end
-        end
 
-        break unless more_pages
-      end # loop
-
+          break unless more_pages
+        end # loop
+      end # with_timeout
       # track total result count
       payload[:result_count] = n_results
 

--- a/lib/net/ldap/version.rb
+++ b/lib/net/ldap/version.rb
@@ -1,5 +1,5 @@
 module Net
   class LDAP
-    VERSION = "0.16.2"
+    VERSION = "0.16.2.aka-jw"
   end
 end

--- a/test/test_auth_adapter.rb
+++ b/test/test_auth_adapter.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class TestAuthAdapter < Test::Unit::TestCase
   class FakeSocket
+    include Net::BER::BERParser
     def initialize(*args)
     end
   end

--- a/test/test_ldap.rb
+++ b/test/test_ldap.rb
@@ -21,6 +21,10 @@ class TestLDAPInstrumentation < Test::Unit::TestCase
       yield @search_success if block_given?
       @search_success
     end
+
+    def with_timeout(timeout = nil, &block)
+      yield
+    end
   end
 
   def setup

--- a/test/test_ldap_connection.rb
+++ b/test/test_ldap_connection.rb
@@ -132,22 +132,24 @@ class TestLDAPConnection < Test::Unit::TestCase
 
   def test_write
     mock = flexmock("socket")
-    mock.should_receive(:write).with([1.to_ber, "request"].to_ber_sequence).and_return(true)
+    mock.extend(Net::BER::BERParser)
+    mock.should_receive(:ber_timeout_write).with([1.to_ber, "request"].to_ber_sequence).and_return(true)
     conn = Net::LDAP::Connection.new(:socket => mock)
     conn.send(:write, "request")
   end
 
   def test_write_with_controls
     mock = flexmock("socket")
-    mock.should_receive(:write).with([1.to_ber, "request", "controls"].to_ber_sequence).and_return(true)
+    mock.extend(Net::BER::BERParser)
+    mock.should_receive(:ber_timeout_write).with([1.to_ber, "request", "controls"].to_ber_sequence).and_return(true)
     conn = Net::LDAP::Connection.new(:socket => mock)
     conn.send(:write, "request", "controls")
   end
 
   def test_write_increments_msgid
     mock = flexmock("socket")
-    mock.should_receive(:write).with([1.to_ber, "request1"].to_ber_sequence).and_return(true)
-    mock.should_receive(:write).with([2.to_ber, "request2"].to_ber_sequence).and_return(true)
+    mock.should_receive(:ber_timeout_write).with([1.to_ber, "request1"].to_ber_sequence).and_return(true)
+    mock.should_receive(:ber_timeout_write).with([2.to_ber, "request2"].to_ber_sequence).and_return(true)
     conn = Net::LDAP::Connection.new(:socket => mock)
     conn.send(:write, "request1")
     conn.send(:write, "request2")
@@ -209,7 +211,7 @@ class TestLDAPConnectionSocketReads < Test::Unit::TestCase
     mock.should_receive(:read_ber)
         .and_return(result1)
         .and_return(result2)
-    mock.should_receive(:write)
+    mock.should_receive(:ber_timeout_write)
     conn = Net::LDAP::Connection.new(:socket => mock)
 
     conn.next_msgid # simulates ongoing query
@@ -230,7 +232,7 @@ class TestLDAPConnectionSocketReads < Test::Unit::TestCase
     mock.should_receive(:read_ber)
         .and_return(result1)
         .and_return(result2)
-    mock.should_receive(:write)
+    mock.should_receive(:ber_timeout_write)
     conn = Net::LDAP::Connection.new(:socket => mock)
 
     conn.next_msgid # simulates ongoing query
@@ -248,7 +250,7 @@ class TestLDAPConnectionSocketReads < Test::Unit::TestCase
     mock.should_receive(:read_ber)
         .and_return(result1)
         .and_return(result2)
-    mock.should_receive(:write)
+    mock.should_receive(:ber_timeout_write)
     conn = Net::LDAP::Connection.new(:socket => mock)
 
     conn.next_msgid # simulates ongoing query
@@ -269,7 +271,7 @@ class TestLDAPConnectionSocketReads < Test::Unit::TestCase
     mock.should_receive(:read_ber)
         .and_return(result1)
         .and_return(result2)
-    mock.should_receive(:write)
+    mock.should_receive(:ber_timeout_write)
     conn = Net::LDAP::Connection.new(:socket => mock)
 
     conn.next_msgid # simulates ongoing query
@@ -287,7 +289,7 @@ class TestLDAPConnectionSocketReads < Test::Unit::TestCase
     mock.should_receive(:read_ber)
         .and_return(result1)
         .and_return(result2)
-    mock.should_receive(:write)
+    mock.should_receive(:ber_timeout_write)
     conn = Net::LDAP::Connection.new(:socket => mock)
     flexmock(Net::LDAP::Connection).should_receive(:wrap_with_ssl).with(mock, {}, nil)
                                    .and_return(mock)
@@ -303,10 +305,11 @@ class TestLDAPConnectionSocketReads < Test::Unit::TestCase
     result2 = make_message(2, app_tag: Net::LDAP::PDU::BindResult)
 
     mock = flexmock("socket")
+    mock.extend(Net::BER::BERParser)
     mock.should_receive(:read_ber)
         .and_return(result1)
         .and_return(result2)
-    mock.should_receive(:write)
+    mock.should_receive(:ber_timeout_write)
     conn = Net::LDAP::Connection.new(:socket => mock)
 
     conn.next_msgid # simulates ongoing query
@@ -325,10 +328,11 @@ class TestLDAPConnectionSocketReads < Test::Unit::TestCase
     result2 = make_message(2, app_tag: Net::LDAP::PDU::BindResult)
 
     mock = flexmock("socket")
+    mock.extend(Net::BER::BERParser)
     mock.should_receive(:read_ber)
         .and_return(result1)
         .and_return(result2)
-    mock.should_receive(:write)
+    mock.should_receive(:ber_timeout_write)
     conn = Net::LDAP::Connection.new(:socket => mock)
 
     conn.next_msgid # simulates ongoing query
@@ -359,7 +363,7 @@ end
 class TestLDAPConnectionErrors < Test::Unit::TestCase
   def setup
     @tcp_socket = flexmock(:connection)
-    @tcp_socket.should_receive(:write)
+    @tcp_socket.should_receive(:ber_timeout_write)
     flexmock(Socket).should_receive(:tcp).and_return(@tcp_socket)
     @connection = Net::LDAP::Connection.new(:host => 'test.mocked.com', :port => 636)
   end
@@ -388,7 +392,8 @@ end
 class TestLDAPConnectionInstrumentation < Test::Unit::TestCase
   def setup
     @tcp_socket = flexmock(:connection)
-    @tcp_socket.should_receive(:write)
+    @tcp_socket.extend(Net::BER::BERParser)
+    @tcp_socket.should_receive(:ber_timeout_write)
     flexmock(Socket).should_receive(:tcp).and_return(@tcp_socket)
 
     @service = MockInstrumentationService.new

--- a/test/test_search.rb
+++ b/test/test_search.rb
@@ -6,6 +6,10 @@ class TestSearch < Test::Unit::TestCase
     def search(args)
       OpenStruct.new(:result_code => Net::LDAP::ResultCodeOperationsError, :message => "error", :success? => false)
     end
+
+    def with_timeout(timeout = nil, &block)
+      yield
+    end
   end
 
   def setup

--- a/test/test_ssl_ber.rb
+++ b/test/test_ssl_ber.rb
@@ -22,6 +22,8 @@ class TestSSLBER < Test::Unit::TestCase
     #
     # TODO: Replace test with real socket
     # https://github.com/ruby-ldap/ruby-net-ldap/pull/121#discussion_r18746386
+    #
+    # without this fix, a number of "warning: SSL session is not started yet" are emitted on the nonblocking reads.
     flexmock(OpenSSL::SSL::SSLSocket)
       .new_instances.should_receive(:connect => nil)
 


### PR DESCRIPTION
This work I did to finish read/write timeouts using non-blocking reads. (partially addressing issue#247?) I've used it successfully in production for some custom services, but I couldn't figure out how to sensibly test the new functionality with the existing testing framework. We'd love to get our changes upstreamed, and I'd love to know if you have any ideas of how to go about testing.