### PR TITLE
Allow ConnectionRefusedError to be captured as Errno::ECONNREFUSED

### DIFF
--- a/Contributors.rdoc
+++ b/Contributors.rdoc
@@ -23,3 +23,4 @@ Contributions since:
 * Cody Cutrer (ccutrer)
 * WoodsBagotAndreMarquesLee
 * Rufus Post (mynameisrufus)
+* Akamai Technologies, Inc. (jwedoff)

--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -1320,7 +1320,7 @@ class Net::LDAP
     # Force connect to see if there's a connection error
     connection.socket
     connection
-  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Net::LDAP::ConnectionRefusedError => e
+  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
     @result = {
       :resultCode   => 52,
       :errorMessage => ResultStrings[ResultCodeUnavailable],

--- a/lib/net/ldap/error.rb
+++ b/lib/net/ldap/error.rb
@@ -1,32 +1,43 @@
 class Net::LDAP
-  class LdapError < StandardError
-    def message
-      "Deprecation warning: Net::LDAP::LdapError is no longer used. Use Net::LDAP::Error or rescue one of it's subclasses. \n" + super
-    end
+  # define Error as a module so that we can use it in exceptions derived from
+  # other classes (e.g. Errno::ECONNREFUSED)
+  module Error; end
+  # define a base class for our "normal" errors
+  class ErrorClass < StandardError;
+    include Error
   end
+  class AlreadyOpenedError < ErrorClass; end
+  class SocketError < ErrorClass; end
 
-  class Error < StandardError; end
+  # make ConnectionRefusedError a kind of Errno::ECONNREFUSED
+  # so that code looking for that exception will work correctly
+  class ConnectionRefusedError < Errno::ECONNREFUSED
+    include Error
 
-  class AlreadyOpenedError < Error; end
-  class SocketError < Error; end
-  class ConnectionRefusedError < Error;
-    def initialize(*args)
+    # don't print a deprication message on initialization or printing the message.
+    # we control those, and code that is using the proper calls will still get the
+    # warnings pointlessly.
+
+    # display the deprication warning on === which will get called any time an exception
+    # goes through a handler like
+    # begin
+    #   ...
+    # rescue ConnectionRefusedError => e
+    #   <handler code>
+    # end
+    #
+    # which *is* the code we want people to stop using
+    def self.===(val)
       warn_deprecation_message
       super
     end
 
-    def message
-      warn_deprecation_message
-      super
-    end
-
-    private
-
-    def warn_deprecation_message
+    def self.warn_deprecation_message
       warn "Deprecation warning: Net::LDAP::ConnectionRefused will be deprecated. Use Errno::ECONNREFUSED instead."
     end
   end
-  class ConnectionError < Error
+
+  class ConnectionError < ErrorClass
     def self.new(errors)
       error = errors.first.first
       if errors.size == 1
@@ -34,7 +45,7 @@ class Net::LDAP
           return Net::LDAP::ConnectionRefusedError.new(error.message)
         end
 
-        return Net::LDAP::Error.new(error.message)
+        return Net::LDAP::ErrorClass.new(error.message)
       end
 
       super
@@ -45,29 +56,29 @@ class Net::LDAP
       super(message)
     end
   end
-  class NoOpenSSLError < Error; end
-  class NoStartTLSResultError < Error; end
-  class NoSearchBaseError < Error; end
-  class StartTLSError < Error; end
-  class EncryptionUnsupportedError < Error; end
-  class EncMethodUnsupportedError < Error; end
-  class AuthMethodUnsupportedError < Error; end
-  class BindingInformationInvalidError < Error; end
-  class NoBindResultError < Error; end
-  class SASLChallengeOverflowError < Error; end
-  class SearchSizeInvalidError < Error; end
-  class SearchScopeInvalidError < Error; end
-  class ResponseTypeInvalidError < Error; end
-  class ResponseMissingOrInvalidError < Error; end
-  class EmptyDNError < Error; end
-  class HashTypeUnsupportedError < Error; end
-  class OperatorError < Error; end
-  class SubstringFilterError < Error; end
-  class SearchFilterError < Error; end
-  class BERInvalidError < Error; end
-  class SearchFilterTypeUnknownError < Error; end
-  class BadAttributeError < Error; end
-  class FilterTypeUnknownError < Error; end
-  class FilterSyntaxInvalidError < Error; end
-  class EntryOverflowError < Error; end
+  class NoOpenSSLError < ErrorClass; end
+  class NoStartTLSResultError < ErrorClass; end
+  class NoSearchBaseError < ErrorClass; end
+  class StartTLSError < ErrorClass; end
+  class EncryptionUnsupportedError < ErrorClass; end
+  class EncMethodUnsupportedError < ErrorClass; end
+  class AuthMethodUnsupportedError < ErrorClass; end
+  class BindingInformationInvalidError < ErrorClass; end
+  class NoBindResultError < ErrorClass; end
+  class SASLChallengeOverflowError < ErrorClass; end
+  class SearchSizeInvalidError < ErrorClass; end
+  class SearchScopeInvalidError < ErrorClass; end
+  class ResponseTypeInvalidError < ErrorClass; end
+  class ResponseMissingOrInvalidError < ErrorClass; end
+  class EmptyDNError < ErrorClass; end
+  class HashTypeUnsupportedError < ErrorClass; end
+  class OperatorError < ErrorClass; end
+  class SubstringFilterError < ErrorClass; end
+  class SearchFilterError < ErrorClass; end
+  class BERInvalidError < ErrorClass; end
+  class SearchFilterTypeUnknownError < ErrorClass; end
+  class BadAttributeError < ErrorClass; end
+  class FilterTypeUnknownError < ErrorClass; end
+  class FilterSyntaxInvalidError < ErrorClass; end
+  class EntryOverflowError < ErrorClass; end
 end

--- a/test/integration/test_bind.rb
+++ b/test/integration/test_bind.rb
@@ -74,7 +74,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
                      ca_file:     CA_FILE },
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -90,7 +90,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
       tls_options: TLS_OPTS.merge(ca_file: CA_FILE),
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -106,7 +106,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
       tls_options: { ca_file: CA_FILE },
     )
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(
@@ -141,7 +141,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
     @ldap.host = '127.0.0.1'
     @ldap.encryption(method: :start_tls, tls_options: {})
     error = assert_raise Net::LDAP::Error,
-                         Net::LDAP::ConnectionRefusedError do
+                         Errno::ECONNREFUSED do
       @ldap.bind BIND_CREDS
     end
     assert_equal(


### PR DESCRIPTION
Modify exceptions to allow Net::LDAP::ConnectionRefusedError to be caught with Errno::ECONNREFUSED (allowing code to start using correct exception), while maintaining compatibility with code using Net::LDAP::ConnectionRefusedError.

Display deprecation warnings for code that attempts to catch Net::LDAP::ConnectionRefusedError, rather than any time a connection refused error is raised.