### PR TITLE
Create first GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - "2.5"
+          - "2.6"
+          - "2.7"
+          - "jruby-9.2"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run tests with Ruby ${{ matrix.ruby }}
+      run: docker-compose run ci-${{ matrix.ruby }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
 addons:
   hosts:
     - ldap.example.org # needed for TLS verification
+    - cert.mismatch.example.org
 
 services:
   - docker

--- a/ci-run.sh
+++ b/ci-run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+gem install bundler
+bundle check || bundle install
+bundle exec rake ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+version: "3.8"
+
+networks:
+  integration_test_network:
+
+services:
+  openldap:
+    image: osixia/openldap:1.4.0
+    networks:
+      integration_test_network:
+        aliases:
+          - ldap.example.org
+          - cert.mismatch.example.org
+    environment:
+      LDAP_TLS_VERIFY_CLIENT: "try"
+      LDAP_SEED_INTERNAL_LDIF_PATH: "/ldif"
+    healthcheck:
+      test: ["CMD", "ldapsearch", "-x", "-s", "base"]
+      interval: 60s
+      start_period: 30s
+      timeout: 5s
+      retries: 1
+    hostname: "ldap.example.org"
+    volumes:
+      - ./test/fixtures/ldif:/ldif:ro
+
+  ci-2.5:
+    image: ruby:2.5
+    entrypoint: /code/ci-run.sh
+    environment:
+      INTEGRATION: openldap
+      INTEGRATION_HOST: ldap.example.org
+    depends_on:
+      - openldap
+    networks:
+      integration_test_network:
+    volumes:
+      - .:/code
+    working_dir: /code
+
+  ci-2.6:
+    image: ruby:2.7
+    entrypoint: /code/ci-run.sh
+    environment:
+      INTEGRATION: openldap
+      INTEGRATION_HOST: ldap.example.org
+    depends_on:
+      - openldap
+    networks:
+      integration_test_network:
+    volumes:
+      - .:/code
+    working_dir: /code
+
+  ci-2.7:
+    image: ruby:2.7
+    entrypoint: /code/ci-run.sh
+    environment:
+      INTEGRATION: openldap
+      INTEGRATION_HOST: ldap.example.org
+    depends_on:
+      - openldap
+    networks:
+      integration_test_network:
+    volumes:
+      - .:/code
+    working_dir: /code
+
+  ci-jruby-9.2:
+    image: jruby:9.2
+    entrypoint: /code/ci-run.sh
+    environment:
+      INTEGRATION: openldap
+      INTEGRATION_HOST: ldap.example.org
+    depends_on:
+      - openldap
+    networks:
+      integration_test_network:
+    volumes:
+      - .:/code
+    working_dir: /code

--- a/test/integration/test_bind.rb
+++ b/test/integration/test_bind.rb
@@ -57,7 +57,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
   end
 
   def test_bind_tls_with_bad_hostname_verify_none_no_ca_opt_merge_passes
-    @ldap.host = '127.0.0.1'
+    @ldap.host = 'cert.mismatch.example.org'
     @ldap.encryption(
       method:      :start_tls,
       tls_options: TLS_OPTS.merge(verify_mode: OpenSSL::SSL::VERIFY_NONE),
@@ -67,7 +67,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
   end
 
   def test_bind_tls_with_bad_hostname_verify_peer_ca_fails
-    @ldap.host = '127.0.0.1'
+    @ldap.host = 'cert.mismatch.example.org'
     @ldap.encryption(
       method:      :start_tls,
       tls_options: { verify_mode: OpenSSL::SSL::VERIFY_PEER,
@@ -84,7 +84,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
   end
 
   def test_bind_tls_with_bad_hostname_ca_default_opt_merge_fails
-    @ldap.host = '127.0.0.1'
+    @ldap.host = 'cert.mismatch.example.org'
     @ldap.encryption(
       method:      :start_tls,
       tls_options: TLS_OPTS.merge(ca_file: CA_FILE),
@@ -100,7 +100,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
   end
 
   def test_bind_tls_with_bad_hostname_ca_no_opt_merge_fails
-    @ldap.host = '127.0.0.1'
+    @ldap.host = 'cert.mismatch.example.org'
     @ldap.encryption(
       method:      :start_tls,
       tls_options: { ca_file: CA_FILE },
@@ -138,7 +138,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
   end
 
   def test_bind_tls_with_bogus_hostname_system_ca_fails
-    @ldap.host = '127.0.0.1'
+    @ldap.host = 'cert.mismatch.example.org'
     @ldap.encryption(method: :start_tls, tls_options: {})
     error = assert_raise Net::LDAP::Error,
                          Net::LDAP::ConnectionRefusedError do
@@ -164,7 +164,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
 
   def test_bind_tls_with_multiple_bogus_hosts
     @ldap.host = nil
-    @ldap.hosts = [['127.0.0.1', 389], ['bogus.example.com', 389]]
+    @ldap.hosts = [['cert.mismatch.example.org', 389], ['bogus.example.com', 389]]
     @ldap.encryption(
       method:      :start_tls,
       tls_options: TLS_OPTS.merge(verify_mode: OpenSSL::SSL::VERIFY_PEER,
@@ -180,7 +180,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
 
   def test_bind_tls_with_multiple_bogus_hosts_no_verification
     @ldap.host = nil
-    @ldap.hosts = [['127.0.0.1', 389], ['bogus.example.com', 389]]
+    @ldap.hosts = [['cert.mismatch.example.org', 389], ['bogus.example.com', 389]]
     @ldap.encryption(
       method:      :start_tls,
       tls_options: TLS_OPTS.merge(verify_mode: OpenSSL::SSL::VERIFY_NONE),
@@ -191,7 +191,7 @@ class TestBindIntegration < LDAPIntegrationTestCase
 
   def test_bind_tls_with_multiple_bogus_hosts_ca_check_only_fails
     @ldap.host = nil
-    @ldap.hosts = [['127.0.0.1', 389], ['bogus.example.com', 389]]
+    @ldap.hosts = [['cert.mismatch.example.org', 389], ['bogus.example.com', 389]]
     @ldap.encryption(
       method: :start_tls,
       tls_options: { ca_file: CA_FILE },


### PR DESCRIPTION
Run our test suite and Rubcop in GitHub Actions.

This also adds a docker-compose.yml that allows for anyone to run the CI jobs fully containerized.

Since our integration tests are running in a docker network, we need another hostname alias to test certificate mismatches so the openldap server is availabe at cert.mismatch.example.org and ldap.example.org but the later is the only one valid per the generated certificate.