### PR TITLE
remove a circular require

### DIFF
--- a/lib/net/ldap/dataset.rb
+++ b/lib/net/ldap/dataset.rb
@@ -1,3 +1,5 @@
+require_relative 'entry'
+
 # -*- ruby encoding: utf-8 -*-
 ##
 # An LDAP Dataset. Used primarily as an intermediate format for converting
@@ -164,5 +166,3 @@ class Net::LDAP::Dataset < Hash
     end
   end
 end
-
-require_relative 'entry' unless defined? Net::LDAP::Entry

--- a/lib/net/ldap/entry.rb
+++ b/lib/net/ldap/entry.rb
@@ -1,3 +1,5 @@
+require_relative 'dataset'
+
 # -*- ruby encoding: utf-8 -*-
 ##
 # Objects of this class represent individual entries in an LDAP directory.
@@ -195,5 +197,3 @@ class Net::LDAP::Entry
   end
   private :setter?
 end # class Entry
-
-require_relative 'dataset' unless defined? Net::LDAP::Dataset


### PR DESCRIPTION
If applied, this commit removes some circular `require`s.

Prior to this change, we had the following circular `require`s

```
require_relative 'entry' unless defined? Net::LDAP::Entry     # dataset
require_relative 'dataset' unless defined? Net::LDAP::Dataset # entry
```

This works (both classes need each other in methods), but it's unnecessary, since calling `require` twice does nothing, since
`$LOADED_FEATURES` has already been updated.

This change moves those `require`s to the toplevel, and removes the `defined?` check.

---

No tests were added, since the existing tests passed without issue.