### PR TITLE
fix for undefined method for write exception

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -690,7 +690,7 @@ class Net::LDAP::Connection #:nodoc:
   #
   # Typically a TCPSocket, but can be a OpenSSL::SSL::SSLSocket
   def socket
-    return @conn if defined? @conn
+    return @conn if defined?(@conn) && !@conn.nil?
 
     # First refactoring uses the existing methods open_connection and
     # prepare_socket to set @conn. Next cleanup would centralize connection


### PR DESCRIPTION
Opening the PR for issue: https://github.com/ruby-ldap/ruby-net-ldap/issues/382

- Method#socket returns @conn sometimes as nil because it is only checking that it is defined or not. (a defined @conn can be nil when it is dead in between)
- checking that along with its definition it should not be nil too.

 Date:      Mon Nov 23 16:27:38 2020 +0530
 Committer: Kanika Gupta <railsstarter@github.com>