### PR TITLE
Fix circular require while loading lib/net/ldap/entry.rb and lib/net/ldap/dataset.rb

### DIFF
--- a/lib/net/ldap/dataset.rb
+++ b/lib/net/ldap/dataset.rb
@@ -1,5 +1,3 @@
-require_relative 'entry'
-
 # -*- ruby encoding: utf-8 -*-
 ##
 # An LDAP Dataset. Used primarily as an intermediate format for converting

--- a/lib/net/ldap/entry.rb
+++ b/lib/net/ldap/entry.rb
@@ -1,5 +1,3 @@
-require_relative 'dataset'
-
 # -*- ruby encoding: utf-8 -*-
 ##
 # Objects of this class represent individual entries in an LDAP directory.


### PR DESCRIPTION
This change removes circular relative_requires from lib/net/ldap/entry.rb and lib/net/ldap/dataset.rb.
Require warnings can be seet at https://github.com/ruby-ldap/ruby-net-ldap/runs/1831714744
These requires  are not necessary as these files are already required in lib/net/ldap.rb file.