### PR TITLE
Fix escaping of # and space in attrs

### DIFF
--- a/lib/net/ldap/dn.rb
+++ b/lib/net/ldap/dn.rb
@@ -192,27 +192,19 @@ class Net::LDAP::DN
   # http://tools.ietf.org/html/rfc2253 section 2.4 lists these exceptions
   # for dn values. All of the following must be escaped in any normal string
   # using a single backslash ('\') as escape.
-  ESCAPES = {
-    ','  => ',',
-    '+'  => '+',
-    '"'  => '"',
-    '\\' => '\\',
-    '<' => '<',
-    '>' => '>',
-    ';' => ';',
-  }
+  ESCAPES = %w[, + " \\ < > ;]
 
-  # Compiled character class regexp using the keys from the above hash, and
+  # Compiled character class regexp using the values from the above list, and
   # checking for a space or # at the start, or space at the end, of the
   # string.
   ESCAPE_RE = Regexp.new("(^ |^#| $|[" +
-                         ESCAPES.keys.map { |e| Regexp.escape(e) }.join +
+                         ESCAPES.map { |e| Regexp.escape(e) }.join +
                          "])")
 
   ##
   # Escape a string for use in a DN value
   def self.escape(string)
-    string.gsub(ESCAPE_RE) { |char| "\\" + ESCAPES[char] }
+    string.gsub(ESCAPE_RE) { |char| "\\" + char }
   end
 
   ##

--- a/test/test_dn.rb
+++ b/test/test_dn.rb
@@ -6,6 +6,14 @@ class TestDN < Test::Unit::TestCase
     assert_equal '\\,\\+\\"\\\\\\<\\>\\;', Net::LDAP::DN.escape(',+"\\<>;')
   end
 
+  def test_escape_pound_sign
+    assert_equal '\\#test', Net::LDAP::DN.escape('#test')
+  end
+
+  def test_escape_space
+    assert_equal '\\ before_after\\ ', Net::LDAP::DN.escape(' before_after ')
+  end
+
   def test_escape_on_initialize
     dn = Net::LDAP::DN.new('cn', ',+"\\<>;', 'ou=company')
     assert_equal 'cn=\\,\\+\\"\\\\\\<\\>\\;,ou=company', dn.to_s


### PR DESCRIPTION
Addresses #398: `Net::LDAP::DN.escape()` raises a `TypeError (no implicit conversion of nil into String)` when attempting to escape a space or # at the beginning of the attribute, or a space at the end.