### PR TITLE
Document `connect_timeout` in Constructor Details

### DIFF
--- a/lib/net/ldap.rb
+++ b/lib/net/ldap.rb
@@ -480,6 +480,8 @@ class Net::LDAP
   #   server says it supports them. This is a fix for MS Active Directory
   # * :instrumentation_service => An object responsible for instrumenting
   #   operations, compatible with ActiveSupport::Notifications' public API.
+  # * :connect_timeout => The TCP socket timeout (in seconds) to use when
+  #   connecting to the LDAP server (default 5 seconds).
   # * :encryption => specifies the encryption to be used in communicating
   #   with the LDAP server. The value must be a Hash containing additional
   #   parameters, which consists of two keys:


### PR DESCRIPTION
Previously, this was only documented in the `Overview` section and missing from https://www.rubydoc.info/github/ruby-ldap/ruby-net-ldap/Net%2FLDAP:initialize