### PR TITLE
Fix openssl error when using multiple hosts

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -30,10 +30,9 @@ class Net::LDAP::Connection #:nodoc:
     @socket_class = socket_class
   end
 
-  def prepare_socket(server, timeout=nil)
+  def prepare_socket(server, timeout=nil, hostname='127.0.0.1')
     socket = server[:socket]
     encryption = server[:encryption]
-    hostname = server[:host]
 
     @conn = socket
     setup_encryption(encryption, timeout, hostname) if encryption
@@ -51,7 +50,7 @@ class Net::LDAP::Connection #:nodoc:
     errors = []
     hosts.each do |host, port|
       begin
-        prepare_socket(server.merge(socket: @socket_class.new(host, port, socket_opts)), timeout)
+        prepare_socket(server.merge(socket: @socket_class.new(host, port, socket_opts)), timeout, host)
         if encryption
           if encryption[:tls_options] &&
              encryption[:tls_options][:verify_mode] &&


### PR DESCRIPTION
There was a bug introduced by https://github.com/ruby-ldap/ruby-net-ldap/pull/406

When using multiple hosts, it will cause the following error:

```
#<Socket:0x00007f856352f270>/opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap/connection.rb:75:in `open_connection': Unable to connect to any given server:  (Net::LDAP::ConnectionError)
  SocketError: getaddrinfo: Name or service not known (non.existent.domain:636)
  OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 peeraddr=216.239.32.58:636 state=error: certificate verify failed (Hostname mismatch) (ldap.google.com:636)
        from /opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap/connection.rb:707:in `socket'
        from /opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap.rb:1329:in `new_connection'
        from /opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap.rb:1308:in `use_connection'
        from /opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap.rb:783:in `block in search'
        from /opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap/instrumentation.rb:19:in `instrument'
        from /opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap.rb:782:in `search'
        from /opt/gitlab/embedded/lib/ruby/gems/3.0.0/gems/net-ldap-0.18.0/lib/net/ldap.rb:1215:in `search_root_dse'
        from ./test.rb:9:in `<main>'
```

This is because `hostname` is being set to `127.0.0.1` when using `hosts`.