### PR TITLE
Update TruffleRuby version on CI to 23.1.1 (latest)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           - "3.2"
           - "jruby-9.3"
           - "jruby-9.4"
-          - "truffleruby-22"
+          - "truffleruby-23"
     steps:
     - uses: actions/checkout@v2
     - name: Run tests with Ruby ${{ matrix.ruby }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,8 @@ services:
     working_dir: /code
 
   # https://github.com/flavorjones/truffleruby/pkgs/container/truffleruby
-  ci-truffleruby-22:
-    image: ghcr.io/flavorjones/truffleruby:22.3.1
+  ci-truffleruby-23:
+    image: ghcr.io/flavorjones/truffleruby:23.1.1
     entrypoint: /code/ci-run.sh
     environment:
       INTEGRATION: openldap

--- a/test/test_ssl_ber.rb
+++ b/test/test_ssl_ber.rb
@@ -31,14 +31,14 @@ class TestSSLBER < Test::Unit::TestCase
 
   def test_transmit_strings
     omit_if RUBY_PLATFORM == "java", "JRuby throws an error without a real socket"
-    omit_if (RUBY_VERSION >= "3.1" || RUBY_ENGINE == "truffleruby"), "Ruby complains about connection not being open"
+    omit_if RUBY_VERSION >= "3.1", "Ruby complains about connection not being open"
 
     assert_equal "foo", transmit("foo")
   end
 
   def test_transmit_ber_encoded_numbers
     omit_if RUBY_PLATFORM == "java", "JRuby throws an error without a real socket"
-    omit_if (RUBY_VERSION >= "3.1" || RUBY_ENGINE == "truffleruby"), "Ruby complains about connection not being open"
+    omit_if RUBY_VERSION >= "3.1", "Ruby complains about connection not being open"
 
     @to.write 1234.to_ber
     assert_equal 1234, @from.read_ber


### PR DESCRIPTION
CI fails right now on TruffleRuby 22 on `bundle check` command ([example](https://github.com/ruby-ldap/ruby-net-ldap/actions/runs/7400222333/job/20133406447)). The issue is fixed in TruffleRuby 23.