### PR TITLE
Add controls for modify and add operations

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -569,7 +569,12 @@ class Net::LDAP::Connection #:nodoc:
       ops.to_ber_sequence,
     ].to_ber_appsequence(Net::LDAP::PDU::ModifyRequest)
 
-    write(request, nil, message_id)
+    controls = args.fetch(:controls, nil)
+    unless controls.nil?
+      controls = controls.to_ber_contextspecific(0)
+    end
+
+    write(request, controls, message_id)
     pdu = queued_read(message_id)
 
     if !pdu || pdu.app_tag != Net::LDAP::PDU::ModifyResponse
@@ -641,7 +646,12 @@ class Net::LDAP::Connection #:nodoc:
     message_id = next_msgid
     request    = [add_dn.to_ber, add_attrs.to_ber_sequence].to_ber_appsequence(Net::LDAP::PDU::AddRequest)
 
-    write(request, nil, message_id)
+    controls = args.fetch(:controls, nil)
+    unless controls.nil?
+      controls = controls.to_ber_contextspecific(0)
+    end
+
+    write(request, controls, message_id)
     pdu = queued_read(message_id)
 
     if !pdu || pdu.app_tag != Net::LDAP::PDU::AddResponse


### PR DESCRIPTION
This builds on the work #411 to allow user-specified controls to be defined for the modify and add operations as well.

I added tests, but they're pretty weak because the controls are in the data sent to the server and I was unable to find a preferred pattern to test that data is sent on the socket. I tried something like the following but didn't have any luck as it'd throw an error that the function was called an incorrect number of times.

```
@tcp_socket.should_receive(:write).with("0[\x02\x01\x01h0\x04,uid=added-user1,ou=People,dc=rubyldap,dc=com0\x00\xA0$0\"\x04\x161.2.840.113556.1.4.801\x01\x01\xFF\x04\x050\x03\x02\x01\x04".b).once.and_return(89)
```

