### PR TITLE
#431, Add `ostruct` as a dependency to the gemspec

### DIFF
--- a/net-ldap.gemspec
+++ b/net-ldap.gemspec
@@ -29,6 +29,7 @@ the most recent LDAP RFCs (4510-4519, plutions of 4520-4532).}
   s.required_ruby_version = ">= 2.0.0"
   s.summary = %q{Net::LDAP for Ruby (also called net-ldap) implements client access for the Lightweight Directory Access Protocol (LDAP), an IETF standard protocol for accessing distributed directory services}
 
+  s.add_dependency("ostruct")
   s.add_development_dependency("flexmock", "~> 1.3")
   s.add_development_dependency("rake", "~> 12.3.3")
   s.add_development_dependency("rubocop", "~> 1.48")


### PR DESCRIPTION
## Description

This commit adds `ostruct` as an explicit dependency in the net-ldap gemspec.

With the release of Ruby 3.3.5 and later versions, users of net-ldap may encounter warnings related to the use of `ostruct` if it is not declared as a dependency. By including `ostruct`, we aim to enhance clarity regarding the gem's requirements and prevent any runtime issues related to missing dependencies.

## Related links

closes #431 